### PR TITLE
CHEF-4085 dlp stored info type resource magic module development

### DIFF
--- a/mmv1/products/dlp/api.yaml
+++ b/mmv1/products/dlp/api.yaml
@@ -47,7 +47,7 @@ objects:
       - !ruby/object:Api::Type::String
         name: 'name'
         description: |
-          The resource name of the job trigger. Set by the server.
+          The resource name of the job trigger.Set by the server.
         output: true
       - !ruby/object:Api::Type::String
         name: 'description'

--- a/mmv1/templates/inspec/examples/google_data_loss_prevention_stored_info_type/google_data_loss_prevention_stored_info_type.erb
+++ b/mmv1/templates/inspec/examples/google_data_loss_prevention_stored_info_type/google_data_loss_prevention_stored_info_type.erb
@@ -1,14 +1,13 @@
 <% gcp_project_id = "#{external_attribute(pwd, 'gcp_project_id', doc_generation)}" -%>
 <% dlp = grab_attributes(pwd)['dlp'] -%>
 
-describe google_data_loss_prevention_stored_info_type(project: <%= gcp_project_id -%>, location: <%= doc_generation ? "'#{dlp['location']}'" : "dlp['location']" -%>, name: <%= doc_generation ? "'#{dlp['name']}'" : "dlp['name']" -%>) do
+describe google_data_loss_prevention_stored_info_type(parent: "projects/#{<%= gcp_project_id -%>}/locations/#{<%= doc_generation ? "'#{dlp['location']}'" : "dlp['location']" -%>}",name: <%= doc_generation ? "'#{dlp['stored_info_type_name']}'" : "dlp['stored_info_type_name']" -%>) do
 it { should exist }
 its('name') { should cmp <%= doc_generation ? "'#{dlp['name']}'" : "dlp['name']" -%> }
 its('type') { should cmp <%= doc_generation ? "'#{dlp['type']}'" : "dlp['type']" -%> }
 its('state') { should cmp <%= doc_generation ? "'#{dlp['state']}'" : "dlp['state']" -%> }
-its('inspectDetails.requestedOptions.snapshotInspectTemplate') { should cmp <%= doc_generation ? "'#{dlp['inspectDetails']['requestedOptions']['snapshotInspectTemplate']}'" : "dlp['inspectDetails']['requestedOptions']['snapshotInspectTemplate']" -%> }
 end
 
-describe google_data_loss_prevention_stored_info_type(project: <%= gcp_project_id -%>, location: <%= dlp['location'] -%>, name: 'nonexistent') do
+describe google_data_loss_prevention_stored_info_type(parent: "projects/#{<%= gcp_project_id -%>}/locations/#{<%= doc_generation ? "'#{dlp['location']}'" : "dlp['location']" -%>}", name: 'nonexistent') do
 it { should_not exist }
 end

--- a/mmv1/templates/inspec/examples/google_data_loss_prevention_stored_info_type/google_data_loss_prevention_stored_info_type.erb
+++ b/mmv1/templates/inspec/examples/google_data_loss_prevention_stored_info_type/google_data_loss_prevention_stored_info_type.erb
@@ -1,0 +1,14 @@
+<% gcp_project_id = "#{external_attribute(pwd, 'gcp_project_id', doc_generation)}" -%>
+<% dlp = grab_attributes(pwd)['dlp'] -%>
+
+describe google_data_loss_prevention_stored_info_type(project: <%= gcp_project_id -%>, location: <%= doc_generation ? "'#{dlp['location']}'" : "dlp['location']" -%>, name: <%= doc_generation ? "'#{dlp['name']}'" : "dlp['name']" -%>) do
+it { should exist }
+its('name') { should cmp <%= doc_generation ? "'#{dlp['name']}'" : "dlp['name']" -%> }
+its('type') { should cmp <%= doc_generation ? "'#{dlp['type']}'" : "dlp['type']" -%> }
+its('state') { should cmp <%= doc_generation ? "'#{dlp['state']}'" : "dlp['state']" -%> }
+its('inspectDetails.requestedOptions.snapshotInspectTemplate') { should cmp <%= doc_generation ? "'#{dlp['inspectDetails']['requestedOptions']['snapshotInspectTemplate']}'" : "dlp['inspectDetails']['requestedOptions']['snapshotInspectTemplate']" -%> }
+end
+
+describe google_data_loss_prevention_stored_info_type(project: <%= gcp_project_id -%>, location: <%= dlp['location'] -%>, name: 'nonexistent') do
+it { should_not exist }
+end

--- a/mmv1/templates/inspec/examples/google_data_loss_prevention_stored_info_type/google_data_loss_prevention_stored_info_type_attributes.erb
+++ b/mmv1/templates/inspec/examples/google_data_loss_prevention_stored_info_type/google_data_loss_prevention_stored_info_type_attributes.erb
@@ -1,0 +1,2 @@
+gcp_project_id = input(:gcp_project_id, value: '<%= external_attribute(pwd, 'gcp_project_id') -%>', description: 'The GCP project identifier.')
+dlp = input('dlp', value: <%= JSON.pretty_generate(grab_attributes(pwd)['dlp']) -%>, description: 'DLP ')

--- a/mmv1/templates/inspec/examples/google_data_loss_prevention_stored_info_type/google_data_loss_prevention_stored_info_types.erb
+++ b/mmv1/templates/inspec/examples/google_data_loss_prevention_stored_info_type/google_data_loss_prevention_stored_info_types.erb
@@ -1,0 +1,10 @@
+<% gcp_project_id = "#{external_attribute(pwd, 'gcp_project_id', doc_generation)}" -%>
+<% dlp = grab_attributes(pwd)['dlp'] -%>
+
+
+describe google_data_loss_prevention_stored_info_types(project: <%= gcp_project_id -%>, location: <%= doc_generation ? "'#{dlp['location']}'" : "dlp['location']" -%>) do
+it { should exist }
+its('names') { should include <%= doc_generation ? "'#{dlp['name']}'" : "dlp['name']" -%> }
+its('types') { should include <%= doc_generation ? "'#{dlp['type']}'" : "dlp['type']" -%> }
+its('states') { should include <%= doc_generation ? "'#{dlp['state']}'" : "dlp['state']" -%> }
+end


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Implement the Magic Module for the DLP StoredInfoType feature. The objective is to configure the DLP StoredInfoType, enabling repetitive DLP API calls for improved data loss prevention.
Tasks:
Resource Configuration: Develop the Magic Module to easily configure the DLP StoredInfoType, specifying the necessary parameters for integration with the DLP API.
Terraform Implementation: Adding Terraform to provision the required infrastructure resources.
Test Cases: Create Test cases templates.
Documentation: Create Documentation templates.
By completing these tasks, we will successfully implement the Magic Module Inspec development for DLP StoredInfoType.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
