### PR TITLE
DLP DeIdentify Templates Magic Module Development

### DIFF
--- a/mmv1/templates/inspec/examples/google_data_loss_prevention_deidentify_template/google_data_loss_prevention_deidentify_template.erb
+++ b/mmv1/templates/inspec/examples/google_data_loss_prevention_deidentify_template/google_data_loss_prevention_deidentify_template.erb
@@ -1,0 +1,11 @@
+<% gcp_project_id = "#{external_attribute(pwd, 'gcp_project_id', doc_generation)}" -%>
+<% dlp = grab_attributes(pwd)['dlp'] -%>
+
+describe google_data_loss_prevention_deidentify_template(parent: "projects/#{<%= gcp_project_id -%>}/locations/#{<%= doc_generation ? "'#{dlp['deidentify_templates'][:location]}'" : "dlp['deidentify_templates'][:location]" -%>}", name: <%= doc_generation ? "'#{dlp['deidentify_templates'][:name]}'" : "dlp['deidentify_templates'][:name]" -%>) do
+  it { should exist }
+  its('display_name') { should cmp <%= doc_generation ? "'#{dlp['deidentify_templates'][:name]}'" : "dlp['deidentify_templates'][:name]" -%> }
+end
+
+describe google_data_loss_prevention_deidentify_template(parent: "projects/#{<%= gcp_project_id -%>}/locations/#{<%= doc_generation ? "'#{dlp['deidentify_templates'][:location]}'" : "dlp['deidentify_templates'][location]" -%>}", name: 'nonexistent') do
+  it { should_not exist }
+end

--- a/mmv1/templates/inspec/examples/google_data_loss_prevention_deidentify_template/google_data_loss_prevention_deidentify_template_attributes.erb
+++ b/mmv1/templates/inspec/examples/google_data_loss_prevention_deidentify_template/google_data_loss_prevention_deidentify_template_attributes.erb
@@ -1,0 +1,2 @@
+gcp_project_id = input(:gcp_project_id, value: '<%= external_attribute(pwd, 'gcp_project_id') -%>', description: 'The GCP project identifier.')
+dlp = input('dlp', value: <%= JSON.pretty_generate(grab_attributes(pwd)['dlp']) -%>, description: 'DLP ')

--- a/mmv1/templates/inspec/examples/google_data_loss_prevention_deidentify_template/google_data_loss_prevention_deidentify_templates.erb
+++ b/mmv1/templates/inspec/examples/google_data_loss_prevention_deidentify_template/google_data_loss_prevention_deidentify_templates.erb
@@ -5,5 +5,4 @@
 describe google_data_loss_prevention_deidentify_templates(parent: "projects/#{<%= gcp_project_id -%>}/locations/#{<%= doc_generation ? "'#{dlp['deidentify_templates'][:location]}'" : "dlp['deidentify_templates'][:location]" -%>}") do
   it { should exist }
   its('display_names') { should include <%= doc_generation ? "'#{dlp['deidentify_templates'][:name]}'" : "dlp['deidentify_templates'][:name]" -%> }
-
 end

--- a/mmv1/templates/inspec/examples/google_data_loss_prevention_deidentify_template/google_data_loss_prevention_deidentify_templates.erb
+++ b/mmv1/templates/inspec/examples/google_data_loss_prevention_deidentify_template/google_data_loss_prevention_deidentify_templates.erb
@@ -1,0 +1,9 @@
+<% gcp_project_id = "#{external_attribute(pwd, 'gcp_project_id', doc_generation)}" -%>
+<% dlp = grab_attributes(pwd)['dlp'] -%>
+
+
+describe google_data_loss_prevention_deidentify_templates(parent: "projects/#{<%= gcp_project_id -%>}/locations/#{<%= doc_generation ? "'#{dlp['deidentify_templates'][:location]}'" : "dlp['deidentify_templates'][:location]" -%>}") do
+  it { should exist }
+  its('display_names') { should include <%= doc_generation ? "'#{dlp['deidentify_templates'][:name]}'" : "dlp['deidentify_templates'][:name]" -%> }
+
+end

--- a/mmv1/templates/inspec/tests/integration/configuration/mm-attributes.yml
+++ b/mmv1/templates/inspec/tests/integration/configuration/mm-attributes.yml
@@ -5,7 +5,7 @@ ssl_policy:
   custom_feature: 'TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384'
   custom_feature2: 'TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384'
 
-topic: 
+topic:
   name: 'inspec-gcp-topic'
 
 subscription:
@@ -232,7 +232,7 @@ standardappversion:
   runtime: nodejs10
   entrypoint: "node ./app.js"
   port: "8080"
-  
+
 ml_model:
   name: ml_model
   region: us-central1
@@ -338,7 +338,7 @@ spannerinstance:
 spannerdatabase:
   name: spdatabase
   instance: spinstance
-  ddl: "CREATE TABLE test (test STRING(MAX),) PRIMARY KEY (test)" 
+  ddl: "CREATE TABLE test (test STRING(MAX),) PRIMARY KEY (test)"
 
 scheduler_job:
   # region must match where the appengine instance is deployed
@@ -437,7 +437,7 @@ logging_metric:
 compute_image:
   name: inspec-image
   source: https://storage.googleapis.com/bosh-gce-raw-stemcells/bosh-stemcell-97.98-google-kvm-ubuntu-xenial-go_agent-raw-1557960142.tar.gz
- 
+
 security_policy:
   name: sec-policy
   action: deny(403)
@@ -492,7 +492,7 @@ sql_database_flag:
   applies_to: MYSQL_5_6
   allowed_string_values: ON
   requires_restart: true
-  
+
 sql_connect:
   region: us-central1
   database_version: POSTGRES_13
@@ -536,5 +536,9 @@ dlp:
   job_trigger_name: "name1"
   job_trigger_display_name: "dp"
   job_trigger_description: "description"
+  deidentify_templates:
+    name: "dlp-template-inspec"
+    location: "europe-west2"
+    type: "Infotype"
 
 


### PR DESCRIPTION
Magic Module development for for DLP DeIdentify Templates feature.

Tasks Completed:

    Test Case Templates: Test case templates have been created to validate the functionality of the implemented Magic  Module. These test cases will be instrumental in ensuring the reliability and correctness of the DLP DeIdentify Template.
    
    Attribute Changes: Added attribute changes required for Test case template

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
