### PR TITLE
CHEF-6199-MAGIC-MODULE-vertex_ai-Dataset - Resource Implementation

### DIFF
--- a/mmv1/products/vertexai/api.yaml
+++ b/mmv1/products/vertexai/api.yaml
@@ -349,3 +349,275 @@ objects:
               The disk utilization of the MetadataStore in bytes.
             output: true
 
+
+    
+  - !ruby/object:Api::Resource
+    name: Dataset
+    base_url: '{{parent}}/datasets'
+    self_link: '{{name}}'
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation':
+      api: 'https://cloud.google.com/vertex-ai/docs'
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
+         path: 'name'
+         base_url: '{op_id}'
+         wait_ms: 1000
+      result: !ruby/object:Api::OpAsync::Result
+         path: 'response'
+         resource_inside_response: true
+      status: !ruby/object:Api::OpAsync::Status
+        path: 'done'
+        complete: True
+        allowed:
+          - True
+          - False
+      error: !ruby/object:Api::OpAsync::Error
+        path: 'error'
+        message: 'message'
+    description: |-
+        A collection of DataItems and Annotations on them.
+    properties:
+  
+      - !ruby/object:Api::Type::Array
+        name: 'savedQueries'
+        description: |
+          All SavedQueries belong to the Dataset will be returned in List/Get Dataset response. The annotation_specs field will not be populated except for UI cases which will only use annotation_spec_count. In CreateDataset request, a SavedQuery is created together if this field is set, up to one SavedQuery can be set in CreateDatasetRequest. The SavedQuery should not contain any AnnotationSpec.
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            - !ruby/object:Api::Type::Integer
+              name: 'annotationSpecCount'
+              description: |
+                Output only. Number of AnnotationSpecs in the context of the SavedQuery.
+            - !ruby/object:Api::Type::String
+              name: 'updateTime'
+              description: |
+                Output only. Timestamp when SavedQuery was last updated.
+            - !ruby/object:Api::Type::Boolean
+              name: 'supportAutomlTraining'
+              description: |
+                Output only. If the Annotations belonging to the SavedQuery can be used for AutoML training.
+            - !ruby/object:Api::Type::String
+              name: 'metadata'
+              description: |
+                Some additional information about the SavedQuery.
+            - !ruby/object:Api::Type::String
+              name: 'problemType'
+              description: |
+                Required. Problem type of the SavedQuery. Allowed values: * IMAGE_CLASSIFICATION_SINGLE_LABEL * IMAGE_CLASSIFICATION_MULTI_LABEL * IMAGE_BOUNDING_POLY * IMAGE_BOUNDING_BOX * TEXT_CLASSIFICATION_SINGLE_LABEL * TEXT_CLASSIFICATION_MULTI_LABEL * TEXT_EXTRACTION * TEXT_SENTIMENT * VIDEO_CLASSIFICATION * VIDEO_OBJECT_TRACKING
+            - !ruby/object:Api::Type::String
+              name: 'name'
+              description: |
+                Output only. Resource name of the SavedQuery.
+            - !ruby/object:Api::Type::String
+              name: 'createTime'
+              description: |
+                Output only. Timestamp when this SavedQuery was created.
+            - !ruby/object:Api::Type::String
+              name: 'etag'
+              description: |
+                Used to perform a consistent read-modify-write update. If not set, a blind "overwrite" update happens.
+            - !ruby/object:Api::Type::String
+              name: 'displayName'
+              description: |
+                Required. The user-defined name of the SavedQuery. The name can be up to 128 characters long and can consist of any UTF-8 characters.
+            - !ruby/object:Api::Type::String
+              name: 'annotationFilter'
+              description: |
+                Output only. Filters on the Annotations in the dataset.
+      - !ruby/object:Api::Type::String
+        name: 'createTime'
+        description: |
+          Output only. Timestamp when this Dataset was created.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'encryptionSpec'
+        description: |
+          Represents a customer-managed encryption key spec that can be applied to a top-level resource.
+        properties:
+            - !ruby/object:Api::Type::String
+              name: 'kmsKeyName'
+              description: |
+                Required. The Cloud KMS resource identifier of the customer managed encryption key used to protect a resource. Has the form: `projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key`. The key needs to be in the same region as where the compute resource is created.
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+          Output only. The resource name of the Dataset.
+      - !ruby/object:Api::Type::String
+        name: 'metadata'
+        description: |
+          Required. Additional information about the Dataset.
+      - !ruby/object:Api::Type::String
+        name: 'etag'
+        description: |
+          Used to perform consistent read-modify-write updates. If not set, a blind "overwrite" update happens.
+      - !ruby/object:Api::Type::String
+        name: 'description'
+        description: |
+          The description of the Dataset.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'labels'
+        description: |
+          The labels with user-defined metadata to organize your Datasets. Label keys and values can be no longer than 64 characters (Unicode codepoints), can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. No more than 64 user labels can be associated with one Dataset (System labels are excluded). See https://goo.gl/xmQnxf for more information and examples of labels. System reserved label keys are prefixed with "aiplatform.googleapis.com/" and are immutable. Following system labels exist for each Dataset: * "aiplatform.googleapis.com/dataset_metadata_schema": output only, its value is the metadata_schema's title.
+        properties:
+              - !ruby/object:Api::Type::String
+                name: 'additionalProperties'
+                description: |
+                
+      - !ruby/object:Api::Type::String
+        name: 'metadataSchemaUri'
+        description: |
+          Required. Points to a YAML file stored on Google Cloud Storage describing additional information about the Dataset. The schema is defined as an OpenAPI 3.0.2 Schema Object. The schema files that can be used here are found in gs://google-cloud-aiplatform/schema/dataset/metadata/.
+      - !ruby/object:Api::Type::String
+        name: 'metadataArtifact'
+        description: |
+          Output only. The resource name of the Artifact that was created in MetadataStore when creating the Dataset. The Artifact resource name pattern is `projects/{project}/locations/{location}/metadataStores/{metadata_store}/artifacts/{artifact}`.
+      - !ruby/object:Api::Type::String
+        name: 'updateTime'
+        description: |
+          Output only. Timestamp when this Dataset was last updated.
+      - !ruby/object:Api::Type::String
+        name: 'dataItemCount'
+        description: |
+          Output only. The number of DataItems in this Dataset. Only apply for non-structured Dataset.
+      - !ruby/object:Api::Type::String
+        name: 'displayName'
+        description: |
+          Required. The user-defined name of the Dataset. The name can be up to 128 characters long and can consist of any UTF-8 characters.
+  
+
+    
+  - !ruby/object:Api::Resource
+    name: Dataset
+    base_url: '{{parent}}/datasets'
+    self_link: '{{name}}'
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation':
+      api: 'https://cloud.google.com/vertex-ai/docs'
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
+         path: 'name'
+         base_url: '{op_id}'
+         wait_ms: 1000
+      result: !ruby/object:Api::OpAsync::Result
+         path: 'response'
+         resource_inside_response: true
+      status: !ruby/object:Api::OpAsync::Status
+        path: 'done'
+        complete: True
+        allowed:
+          - True
+          - False
+      error: !ruby/object:Api::OpAsync::Error
+        path: 'error'
+        message: 'message'
+    description: |-
+        A collection of DataItems and Annotations on them.
+    properties:
+  
+      - !ruby/object:Api::Type::Array
+        name: 'savedQueries'
+        description: |
+          All SavedQueries belong to the Dataset will be returned in List/Get Dataset response. The annotation_specs field will not be populated except for UI cases which will only use annotation_spec_count. In CreateDataset request, a SavedQuery is created together if this field is set, up to one SavedQuery can be set in CreateDatasetRequest. The SavedQuery should not contain any AnnotationSpec.
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            - !ruby/object:Api::Type::Integer
+              name: 'annotationSpecCount'
+              description: |
+                Output only. Number of AnnotationSpecs in the context of the SavedQuery.
+            - !ruby/object:Api::Type::String
+              name: 'updateTime'
+              description: |
+                Output only. Timestamp when SavedQuery was last updated.
+            - !ruby/object:Api::Type::Boolean
+              name: 'supportAutomlTraining'
+              description: |
+                Output only. If the Annotations belonging to the SavedQuery can be used for AutoML training.
+            - !ruby/object:Api::Type::String
+              name: 'metadata'
+              description: |
+                Some additional information about the SavedQuery.
+            - !ruby/object:Api::Type::String
+              name: 'problemType'
+              description: |
+                Required. Problem type of the SavedQuery. Allowed values: * IMAGE_CLASSIFICATION_SINGLE_LABEL * IMAGE_CLASSIFICATION_MULTI_LABEL * IMAGE_BOUNDING_POLY * IMAGE_BOUNDING_BOX * TEXT_CLASSIFICATION_SINGLE_LABEL * TEXT_CLASSIFICATION_MULTI_LABEL * TEXT_EXTRACTION * TEXT_SENTIMENT * VIDEO_CLASSIFICATION * VIDEO_OBJECT_TRACKING
+            - !ruby/object:Api::Type::String
+              name: 'name'
+              description: |
+                Output only. Resource name of the SavedQuery.
+            - !ruby/object:Api::Type::String
+              name: 'createTime'
+              description: |
+                Output only. Timestamp when this SavedQuery was created.
+            - !ruby/object:Api::Type::String
+              name: 'etag'
+              description: |
+                Used to perform a consistent read-modify-write update. If not set, a blind "overwrite" update happens.
+            - !ruby/object:Api::Type::String
+              name: 'displayName'
+              description: |
+                Required. The user-defined name of the SavedQuery. The name can be up to 128 characters long and can consist of any UTF-8 characters.
+            - !ruby/object:Api::Type::String
+              name: 'annotationFilter'
+              description: |
+                Output only. Filters on the Annotations in the dataset.
+      - !ruby/object:Api::Type::String
+        name: 'createTime'
+        description: |
+          Output only. Timestamp when this Dataset was created.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'encryptionSpec'
+        description: |
+          Represents a customer-managed encryption key spec that can be applied to a top-level resource.
+        properties:
+            - !ruby/object:Api::Type::String
+              name: 'kmsKeyName'
+              description: |
+                Required. The Cloud KMS resource identifier of the customer managed encryption key used to protect a resource. Has the form: `projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key`. The key needs to be in the same region as where the compute resource is created.
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+          Output only. The resource name of the Dataset.
+      - !ruby/object:Api::Type::String
+        name: 'metadata'
+        description: |
+          Required. Additional information about the Dataset.
+      - !ruby/object:Api::Type::String
+        name: 'etag'
+        description: |
+          Used to perform consistent read-modify-write updates. If not set, a blind "overwrite" update happens.
+      - !ruby/object:Api::Type::String
+        name: 'description'
+        description: |
+          The description of the Dataset.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'labels'
+        description: |
+          The labels with user-defined metadata to organize your Datasets. Label keys and values can be no longer than 64 characters (Unicode codepoints), can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. No more than 64 user labels can be associated with one Dataset (System labels are excluded). See https://goo.gl/xmQnxf for more information and examples of labels. System reserved label keys are prefixed with "aiplatform.googleapis.com/" and are immutable. Following system labels exist for each Dataset: * "aiplatform.googleapis.com/dataset_metadata_schema": output only, its value is the metadata_schema's title.
+        properties:
+              - !ruby/object:Api::Type::String
+                name: 'additionalProperties'
+                description: |
+                
+      - !ruby/object:Api::Type::String
+        name: 'metadataSchemaUri'
+        description: |
+          Required. Points to a YAML file stored on Google Cloud Storage describing additional information about the Dataset. The schema is defined as an OpenAPI 3.0.2 Schema Object. The schema files that can be used here are found in gs://google-cloud-aiplatform/schema/dataset/metadata/.
+      - !ruby/object:Api::Type::String
+        name: 'metadataArtifact'
+        description: |
+          Output only. The resource name of the Artifact that was created in MetadataStore when creating the Dataset. The Artifact resource name pattern is `projects/{project}/locations/{location}/metadataStores/{metadata_store}/artifacts/{artifact}`.
+      - !ruby/object:Api::Type::String
+        name: 'updateTime'
+        description: |
+          Output only. Timestamp when this Dataset was last updated.
+      - !ruby/object:Api::Type::String
+        name: 'dataItemCount'
+        description: |
+          Output only. The number of DataItems in this Dataset. Only apply for non-structured Dataset.
+      - !ruby/object:Api::Type::String
+        name: 'displayName'
+        description: |
+          Required. The user-defined name of the Dataset. The name can be up to 128 characters long and can consist of any UTF-8 characters.
+  

--- a/mmv1/products/vertexai/api.yaml
+++ b/mmv1/products/vertexai/api.yaml
@@ -621,3 +621,139 @@ objects:
         description: |
           Required. The user-defined name of the Dataset. The name can be up to 128 characters long and can consist of any UTF-8 characters.
   
+
+    
+  - !ruby/object:Api::Resource
+    name: Dataset
+    base_url: '{{parent}}/datasets'
+    self_link: '{{name}}'
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation':
+      api: 'https://cloud.google.com/vertex-ai/docs'
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
+         path: 'name'
+         base_url: '{op_id}'
+         wait_ms: 1000
+      result: !ruby/object:Api::OpAsync::Result
+         path: 'response'
+         resource_inside_response: true
+      status: !ruby/object:Api::OpAsync::Status
+        path: 'done'
+        complete: True
+        allowed:
+          - True
+          - False
+      error: !ruby/object:Api::OpAsync::Error
+        path: 'error'
+        message: 'message'
+    description: |-
+        A collection of DataItems and Annotations on them.
+    properties:
+  
+      - !ruby/object:Api::Type::Array
+        name: 'savedQueries'
+        description: |
+          All SavedQueries belong to the Dataset will be returned in List/Get Dataset response. The annotation_specs field will not be populated except for UI cases which will only use annotation_spec_count. In CreateDataset request, a SavedQuery is created together if this field is set, up to one SavedQuery can be set in CreateDatasetRequest. The SavedQuery should not contain any AnnotationSpec.
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            - !ruby/object:Api::Type::Integer
+              name: 'annotationSpecCount'
+              description: |
+                Output only. Number of AnnotationSpecs in the context of the SavedQuery.
+            - !ruby/object:Api::Type::String
+              name: 'updateTime'
+              description: |
+                Output only. Timestamp when SavedQuery was last updated.
+            - !ruby/object:Api::Type::Boolean
+              name: 'supportAutomlTraining'
+              description: |
+                Output only. If the Annotations belonging to the SavedQuery can be used for AutoML training.
+            - !ruby/object:Api::Type::String
+              name: 'metadata'
+              description: |
+                Some additional information about the SavedQuery.
+            - !ruby/object:Api::Type::String
+              name: 'problemType'
+              description: |
+                Required. Problem type of the SavedQuery. Allowed values: * IMAGE_CLASSIFICATION_SINGLE_LABEL * IMAGE_CLASSIFICATION_MULTI_LABEL * IMAGE_BOUNDING_POLY * IMAGE_BOUNDING_BOX * TEXT_CLASSIFICATION_SINGLE_LABEL * TEXT_CLASSIFICATION_MULTI_LABEL * TEXT_EXTRACTION * TEXT_SENTIMENT * VIDEO_CLASSIFICATION * VIDEO_OBJECT_TRACKING
+            - !ruby/object:Api::Type::String
+              name: 'name'
+              description: |
+                Output only. Resource name of the SavedQuery.
+            - !ruby/object:Api::Type::String
+              name: 'createTime'
+              description: |
+                Output only. Timestamp when this SavedQuery was created.
+            - !ruby/object:Api::Type::String
+              name: 'etag'
+              description: |
+                Used to perform a consistent read-modify-write update. If not set, a blind "overwrite" update happens.
+            - !ruby/object:Api::Type::String
+              name: 'displayName'
+              description: |
+                Required. The user-defined name of the SavedQuery. The name can be up to 128 characters long and can consist of any UTF-8 characters.
+            - !ruby/object:Api::Type::String
+              name: 'annotationFilter'
+              description: |
+                Output only. Filters on the Annotations in the dataset.
+      - !ruby/object:Api::Type::String
+        name: 'createTime'
+        description: |
+          Output only. Timestamp when this Dataset was created.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'encryptionSpec'
+        description: |
+          Represents a customer-managed encryption key spec that can be applied to a top-level resource.
+        properties:
+            - !ruby/object:Api::Type::String
+              name: 'kmsKeyName'
+              description: |
+                Required. The Cloud KMS resource identifier of the customer managed encryption key used to protect a resource. Has the form: `projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key`. The key needs to be in the same region as where the compute resource is created.
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+          Output only. The resource name of the Dataset.
+      - !ruby/object:Api::Type::String
+        name: 'metadata'
+        description: |
+          Required. Additional information about the Dataset.
+      - !ruby/object:Api::Type::String
+        name: 'etag'
+        description: |
+          Used to perform consistent read-modify-write updates. If not set, a blind "overwrite" update happens.
+      - !ruby/object:Api::Type::String
+        name: 'description'
+        description: |
+          The description of the Dataset.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'labels'
+        description: |
+          The labels with user-defined metadata to organize your Datasets. Label keys and values can be no longer than 64 characters (Unicode codepoints), can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. No more than 64 user labels can be associated with one Dataset (System labels are excluded). See https://goo.gl/xmQnxf for more information and examples of labels. System reserved label keys are prefixed with "aiplatform.googleapis.com/" and are immutable. Following system labels exist for each Dataset: * "aiplatform.googleapis.com/dataset_metadata_schema": output only, its value is the metadata_schema's title.
+        properties:
+              - !ruby/object:Api::Type::String
+                name: 'additionalProperties'
+                description: |
+                
+      - !ruby/object:Api::Type::String
+        name: 'metadataSchemaUri'
+        description: |
+          Required. Points to a YAML file stored on Google Cloud Storage describing additional information about the Dataset. The schema is defined as an OpenAPI 3.0.2 Schema Object. The schema files that can be used here are found in gs://google-cloud-aiplatform/schema/dataset/metadata/.
+      - !ruby/object:Api::Type::String
+        name: 'metadataArtifact'
+        description: |
+          Output only. The resource name of the Artifact that was created in MetadataStore when creating the Dataset. The Artifact resource name pattern is `projects/{project}/locations/{location}/metadataStores/{metadata_store}/artifacts/{artifact}`.
+      - !ruby/object:Api::Type::String
+        name: 'updateTime'
+        description: |
+          Output only. Timestamp when this Dataset was last updated.
+      - !ruby/object:Api::Type::String
+        name: 'dataItemCount'
+        description: |
+          Output only. The number of DataItems in this Dataset. Only apply for non-structured Dataset.
+      - !ruby/object:Api::Type::String
+        name: 'displayName'
+        description: |
+          Required. The user-defined name of the Dataset. The name can be up to 128 characters long and can consist of any UTF-8 characters.
+  

--- a/mmv1/products/vertexai/api.yaml
+++ b/mmv1/products/vertexai/api.yaml
@@ -757,3 +757,139 @@ objects:
         description: |
           Required. The user-defined name of the Dataset. The name can be up to 128 characters long and can consist of any UTF-8 characters.
   
+
+    
+  - !ruby/object:Api::Resource
+    name: Dataset
+    base_url: '{{parent}}/datasets'
+    self_link: '{{name}}'
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation':
+      api: 'https://cloud.google.com/vertex-ai/docs'
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
+         path: 'name'
+         base_url: '{op_id}'
+         wait_ms: 1000
+      result: !ruby/object:Api::OpAsync::Result
+         path: 'response'
+         resource_inside_response: true
+      status: !ruby/object:Api::OpAsync::Status
+        path: 'done'
+        complete: True
+        allowed:
+          - True
+          - False
+      error: !ruby/object:Api::OpAsync::Error
+        path: 'error'
+        message: 'message'
+    description: |-
+        A collection of DataItems and Annotations on them.
+    properties:
+  
+      - !ruby/object:Api::Type::Array
+        name: 'savedQueries'
+        description: |
+          All SavedQueries belong to the Dataset will be returned in List/Get Dataset response. The annotation_specs field will not be populated except for UI cases which will only use annotation_spec_count. In CreateDataset request, a SavedQuery is created together if this field is set, up to one SavedQuery can be set in CreateDatasetRequest. The SavedQuery should not contain any AnnotationSpec.
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            - !ruby/object:Api::Type::Integer
+              name: 'annotationSpecCount'
+              description: |
+                Output only. Number of AnnotationSpecs in the context of the SavedQuery.
+            - !ruby/object:Api::Type::String
+              name: 'updateTime'
+              description: |
+                Output only. Timestamp when SavedQuery was last updated.
+            - !ruby/object:Api::Type::Boolean
+              name: 'supportAutomlTraining'
+              description: |
+                Output only. If the Annotations belonging to the SavedQuery can be used for AutoML training.
+            - !ruby/object:Api::Type::String
+              name: 'metadata'
+              description: |
+                Some additional information about the SavedQuery.
+            - !ruby/object:Api::Type::String
+              name: 'problemType'
+              description: |
+                Required. Problem type of the SavedQuery. Allowed values: * IMAGE_CLASSIFICATION_SINGLE_LABEL * IMAGE_CLASSIFICATION_MULTI_LABEL * IMAGE_BOUNDING_POLY * IMAGE_BOUNDING_BOX * TEXT_CLASSIFICATION_SINGLE_LABEL * TEXT_CLASSIFICATION_MULTI_LABEL * TEXT_EXTRACTION * TEXT_SENTIMENT * VIDEO_CLASSIFICATION * VIDEO_OBJECT_TRACKING
+            - !ruby/object:Api::Type::String
+              name: 'name'
+              description: |
+                Output only. Resource name of the SavedQuery.
+            - !ruby/object:Api::Type::String
+              name: 'createTime'
+              description: |
+                Output only. Timestamp when this SavedQuery was created.
+            - !ruby/object:Api::Type::String
+              name: 'etag'
+              description: |
+                Used to perform a consistent read-modify-write update. If not set, a blind "overwrite" update happens.
+            - !ruby/object:Api::Type::String
+              name: 'displayName'
+              description: |
+                Required. The user-defined name of the SavedQuery. The name can be up to 128 characters long and can consist of any UTF-8 characters.
+            - !ruby/object:Api::Type::String
+              name: 'annotationFilter'
+              description: |
+                Output only. Filters on the Annotations in the dataset.
+      - !ruby/object:Api::Type::String
+        name: 'createTime'
+        description: |
+          Output only. Timestamp when this Dataset was created.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'encryptionSpec'
+        description: |
+          Represents a customer-managed encryption key spec that can be applied to a top-level resource.
+        properties:
+            - !ruby/object:Api::Type::String
+              name: 'kmsKeyName'
+              description: |
+                Required. The Cloud KMS resource identifier of the customer managed encryption key used to protect a resource. Has the form: `projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key`. The key needs to be in the same region as where the compute resource is created.
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+          Output only. The resource name of the Dataset.
+      - !ruby/object:Api::Type::String
+        name: 'metadata'
+        description: |
+          Required. Additional information about the Dataset.
+      - !ruby/object:Api::Type::String
+        name: 'etag'
+        description: |
+          Used to perform consistent read-modify-write updates. If not set, a blind "overwrite" update happens.
+      - !ruby/object:Api::Type::String
+        name: 'description'
+        description: |
+          The description of the Dataset.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'labels'
+        description: |
+          The labels with user-defined metadata to organize your Datasets. Label keys and values can be no longer than 64 characters (Unicode codepoints), can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. No more than 64 user labels can be associated with one Dataset (System labels are excluded). See https://goo.gl/xmQnxf for more information and examples of labels. System reserved label keys are prefixed with "aiplatform.googleapis.com/" and are immutable. Following system labels exist for each Dataset: * "aiplatform.googleapis.com/dataset_metadata_schema": output only, its value is the metadata_schema's title.
+        properties:
+              - !ruby/object:Api::Type::String
+                name: 'additionalProperties'
+                description: |
+                
+      - !ruby/object:Api::Type::String
+        name: 'metadataSchemaUri'
+        description: |
+          Required. Points to a YAML file stored on Google Cloud Storage describing additional information about the Dataset. The schema is defined as an OpenAPI 3.0.2 Schema Object. The schema files that can be used here are found in gs://google-cloud-aiplatform/schema/dataset/metadata/.
+      - !ruby/object:Api::Type::String
+        name: 'metadataArtifact'
+        description: |
+          Output only. The resource name of the Artifact that was created in MetadataStore when creating the Dataset. The Artifact resource name pattern is `projects/{project}/locations/{location}/metadataStores/{metadata_store}/artifacts/{artifact}`.
+      - !ruby/object:Api::Type::String
+        name: 'updateTime'
+        description: |
+          Output only. Timestamp when this Dataset was last updated.
+      - !ruby/object:Api::Type::String
+        name: 'dataItemCount'
+        description: |
+          Output only. The number of DataItems in this Dataset. Only apply for non-structured Dataset.
+      - !ruby/object:Api::Type::String
+        name: 'displayName'
+        description: |
+          Required. The user-defined name of the Dataset. The name can be up to 128 characters long and can consist of any UTF-8 characters.
+  

--- a/mmv1/products/vertexai/inspec.yaml
+++ b/mmv1/products/vertexai/inspec.yaml
@@ -1,0 +1,15 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Provider::Inspec::Config
+overrides: !ruby/object:Overrides::ResourceOverrides

--- a/mmv1/templates/inspec/examples/google_vertex_ai_dataset/google_vertex_ai_dataset.erb
+++ b/mmv1/templates/inspec/examples/google_vertex_ai_dataset/google_vertex_ai_dataset.erb
@@ -1,0 +1,5 @@
+<% gcp_project_id = "#{external_attribute(pwd, 'gcp_project_id', doc_generation)}" -%>
+   <% dataset = grab_attributes(pwd)['dataset'] -%>
+   describe google_vertex_ai_dataset(name: <%= doc_generation ? "' #{dataset['name']}'":"dataset['name']" -%>) do
+     it { should exist }
+   end

--- a/mmv1/templates/inspec/examples/google_vertex_ai_dataset/google_vertex_ai_dataset_attributes.erb
+++ b/mmv1/templates/inspec/examples/google_vertex_ai_dataset/google_vertex_ai_dataset_attributes.erb
@@ -1,0 +1,3 @@
+gcp_project_id = input(:gcp_project_id, value: '<%= external_attribute(pwd, 'gcp_project_id') -%>', description: 'The GCP project identifier.')
+
+  dataset = input('dataset', value: <%= JSON.pretty_generate(grab_attributes(pwd)['dataset']) -%>, description: 'dataset description')

--- a/mmv1/templates/inspec/examples/google_vertex_ai_dataset/google_vertex_ai_datasets.erb
+++ b/mmv1/templates/inspec/examples/google_vertex_ai_dataset/google_vertex_ai_datasets.erb
@@ -1,0 +1,5 @@
+<% gcp_project_id = "#{external_attribute(pwd, 'gcp_project_id', doc_generation)}" -%>
+  <% dataset = grab_attributes(pwd)['dataset'] -%>
+  describe google_vertex_ai_dataset(parent: <%= doc_generation ? "' #{dataset['parent']}'":"dataset['parent']" -%>) do
+    it { should exist }
+  end

--- a/mmv1/templates/inspec/tests/integration/build/gcp-mm.tf
+++ b/mmv1/templates/inspec/tests/integration/build/gcp-mm.tf
@@ -1405,3 +1405,10 @@ resource "google_healthcare_dataset" "default" {
   time_zone = "UTC"
 }
 
+
+resource "google_healthcare_dataset" "default" {
+  name      = "example-dataset-${local.name_suffix}"
+  location  = "us-central1"
+  time_zone = "UTC"
+}
+

--- a/mmv1/templates/inspec/tests/integration/build/gcp-mm.tf
+++ b/mmv1/templates/inspec/tests/integration/build/gcp-mm.tf
@@ -1384,3 +1384,17 @@ resource "google_data_loss_prevention_stored_info_type" "basic" {
 
 
 
+
+resource "google_healthcare_dataset" "default" {
+  name      = "example-dataset-${local.name_suffix}"
+  location  = "us-central1"
+  time_zone = "UTC"
+}
+
+
+resource "google_healthcare_dataset" "default" {
+  name      = "example-dataset-${local.name_suffix}"
+  location  = "us-central1"
+  time_zone = "UTC"
+}
+

--- a/mmv1/templates/inspec/tests/integration/build/gcp-mm.tf
+++ b/mmv1/templates/inspec/tests/integration/build/gcp-mm.tf
@@ -1398,3 +1398,10 @@ resource "google_healthcare_dataset" "default" {
   time_zone = "UTC"
 }
 
+
+resource "google_healthcare_dataset" "default" {
+  name      = "example-dataset-${local.name_suffix}"
+  location  = "us-central1"
+  time_zone = "UTC"
+}
+


### PR DESCRIPTION
Automatically generated by magic modules for service: vertex_ai and resource: Dataset.
This commit includes the following changes:
- Singular Resource ERB File
- Plural Resource ERB File 
- Terraform configuration
- api.yaml configuration for product vertex_ai and resource Dataset