### PR TITLE
CHEF-6275-MAGIC-MODULE-compute-PublicDelegatedPrefix - Resource Implementation

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -19821,3 +19821,109 @@ objects:
           - :READY_TO_ANNOUNCE
           - :ANNOUNCED
           - :DELETING
+
+    
+  - !ruby/object:Api::Resource
+    name: 'PublicDelegatedPrefix'
+    kind: 'compute#publicdelegatedprefixes'
+    base_url: 'projects/{{project}}/regions/{{region}}/publicDelegatedPrefixes/{{publicDelegatedPrefix}}'
+    collection_url_key: 'items'
+    input: true
+    has_self_link: true
+    description: |
+      An instance is a virtual machine (VM) hosted on Google's infrastructure.
+    properties:
+     - !ruby/object:Api::Type::String
+       name: 'kind'
+       description: |
+        Type of the resource. Always compute#publicDelegatedPrefix for public delegated prefixes. 
+     - !ruby/object:Api::Type::String
+       name: 'id'
+       description: |
+        string (uint64 format) The unique identifier for the resource type. The server generates this identifier. 
+     - !ruby/object:Api::Type::String
+       name: 'creationTimestamp'
+       description: |
+        Creation timestamp in RFC3339 text format. 
+     - !ruby/object:Api::Type::String
+       name: 'name'
+       description: |
+        Name of the resource. Provided by the client when the resource is created. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression [a-z]([-a-z0-9]*[a-z0-9])? which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash. 
+     - !ruby/object:Api::Type::String
+       name: 'description'
+       description: |
+        An optional description of this resource. Provide this property when you create the resource. 
+     - !ruby/object:Api::Type::String
+       name: 'selfLink'
+       description: |
+        Server-defined URL for the resource. 
+     - !ruby/object:Api::Type::String
+       name: 'region'
+       description: |
+        URL of the region where the public delegated prefix resides. This field applies only to the region resource. You must specify this field as part of the HTTP request URL. It is not settable as a field in the request body. 
+     - !ruby/object:Api::Type::String
+       name: 'ipCidrRange'
+       description: |
+        The IP address range, in CIDR format, represented by this public delegated prefix. 
+     - !ruby/object:Api::Type::Enum
+       name: 'status'
+       description: |
+        The status of the public delegated prefix, which can be one of following values:  INITIALIZING The public delegated prefix is being initialized and  addresses cannot be created yet. READY_TO_ANNOUNCE The public delegated prefix is a live migration  prefix and is active. ANNOUNCED The public delegated prefix is active. DELETING The public delegated prefix is being deprovsioned. 
+       values:
+       - :INITIALIZING
+       - :READY_TO_ANNOUNCE
+       - :ANNOUNCED
+       - :DELETING
+     
+       default_value: :INITIALIZING
+     - !ruby/object:Api::Type::String
+       name: 'parentPrefix'
+       description: |
+        The URL of parent prefix. Either PublicAdvertisedPrefix or PublicDelegatedPrefix. 
+     - !ruby/object:Api::Type::Array
+       name: 'publicDelegatedSubPrefixs'
+       description: |
+        object The list of sub public delegated prefixes that exist for this public delegated prefix. 
+       item_type: !ruby/object:Api::Type::NestedObject
+         properties:
+           - !ruby/object:Api::Type::String
+             name: 'name'
+             description: |
+                    The name of the sub public delegated prefix. 
+           - !ruby/object:Api::Type::String
+             name: 'description'
+             description: |
+                    An optional description of this resource. Provide this property when you create the resource. 
+           - !ruby/object:Api::Type::String
+             name: 'region'
+             description: |
+                    The region of the sub public delegated prefix if it is regional. If absent, the sub prefix is global. 
+           - !ruby/object:Api::Type::Enum
+             name: 'status'
+             description: |
+                    The status of the sub public delegated prefix. 
+             values:
+             - :VALUE_1
+     
+             default_value: :VALUE_1
+           - !ruby/object:Api::Type::String
+             name: 'ipCidrRange'
+             description: |
+                    The IP address range, in CIDR format, represented by this sub public delegated prefix. 
+           - !ruby/object:Api::Type::String
+             name: 'delegateeProject'
+             description: |
+                    Name of the project scoping this PublicDelegatedSubPrefix. 
+           - !ruby/object:Api::Type::Boolean
+             name: 'isAddress'
+             description: |
+                    boolean Whether the sub prefix is delegated to create Address resources in the delegatee project. 
+     - !ruby/object:Api::Type::Boolean
+       name: 'isLiveMigration'
+       description: |
+        boolean If true, the prefix will be live migrated. 
+     - !ruby/object:Api::Type::String
+       name: 'fingerprint'
+       description: |
+        string (bytes format) Fingerprint of this resource. A hash of the contents stored in this object. This field is used in optimistic locking. This field will be ignored when inserting a new PublicDelegatedPrefix. An up-to-date fingerprint must be provided in order to update the PublicDelegatedPrefix, otherwise the request will fail with error 412 conditionNotMet. To see the latest fingerprint, make a get() request to retrieve a PublicDelegatedPrefix. A base64-encoded string. 
+     

--- a/mmv1/templates/inspec/examples/google_compute_public_delegated_prefix/google_compute_public_delegated_prefix.erb
+++ b/mmv1/templates/inspec/examples/google_compute_public_delegated_prefix/google_compute_public_delegated_prefix.erb
@@ -1,5 +1,5 @@
 <% gcp_project_id = "#{external_attribute(pwd, 'gcp_project_id', doc_generation)}" -%>
-<% public_delegated_prefix = grab_attributes(pwd)['public_delegated_prefix'] -%>
-describe google_compute_public_delegated_prefix(project: <%= gcp_project_id -%>, region: 'us-east1-b', name: <%= doc_generation ? "'#{public_delegated_prefix['name']}'" : "public_delegated_prefix['name']" -%>) do
-  it { should exist }
-end
+   <% public_delegated_prefix = grab_attributes(pwd)['public_delegated_prefix'] -%>
+   describe google_compute_public_delegated_prefix(project: <%= gcp_project_id -%>, region: <%= doc_generation ? "' #{public_delegated_prefix['region']}'":"public_delegated_prefix['region']" -%>, publicDelegatedPrefix: <%= doc_generation ? "' #{public_delegated_prefix['publicDelegatedPrefix']}'":"public_delegated_prefix['publicDelegatedPrefix']" -%>) do
+     it { should exist }
+   end

--- a/mmv1/templates/inspec/examples/google_compute_public_delegated_prefix/google_compute_public_delegated_prefix_attributes.erb
+++ b/mmv1/templates/inspec/examples/google_compute_public_delegated_prefix/google_compute_public_delegated_prefix_attributes.erb
@@ -1,2 +1,3 @@
 gcp_project_id = input(:gcp_project_id, value: '<%= external_attribute(pwd, 'gcp_project_id') -%>', description: 'The GCP project identifier.')
-public_delegated_prefix = input('public_delegated_prefix', value: <%= JSON.pretty_generate(grab_attributes(pwd)['public_delegated_prefix']) -%>, description: 'PublicDelegatedPrefix resource in the given region')
+
+  public_delegated_prefix = input('public_delegated_prefix', value: <%= JSON.pretty_generate(grab_attributes(pwd)['public_delegated_prefix']) -%>, description: 'public_delegated_prefix description')

--- a/mmv1/templates/inspec/examples/google_compute_public_delegated_prefix/google_compute_public_delegated_prefixes.erb
+++ b/mmv1/templates/inspec/examples/google_compute_public_delegated_prefix/google_compute_public_delegated_prefixes.erb
@@ -1,4 +1,5 @@
 <% gcp_project_id = "#{external_attribute(pwd, 'gcp_project_id', doc_generation)}" -%>
-describe google_compute_public_delegated_prefixes(project: <%= gcp_project_id -%>, region: 'us-east1-b') do
-  it { should exist }
-end
+  <% public_delegated_prefix = grab_attributes(pwd)['public_delegated_prefix'] -%>
+  describe google_compute_public_delegated_prefix(project: <%= gcp_project_id -%>, region: <%= doc_generation ? "' #{public_delegated_prefix['region']}'":"public_delegated_prefix['region']" -%>) do
+    it { should exist }
+  end


### PR DESCRIPTION
Automatically generated by magic modules for service: compute and resource: PublicDelegatedPrefix.
This commit includes the following changes:
- Singular Resource ERB File
- Plural Resource ERB File 
- Terraform configuration
- api.yaml configuration for product compute and resource PublicDelegatedPrefix