### PR TITLE
CHEF-5574-MAGIC-MODULE-vertex_ai-NasJobs__nasTrialDetail - Resource Implementation

### DIFF
--- a/mmv1/products/vertexai/api.yaml
+++ b/mmv1/products/vertexai/api.yaml
@@ -3689,3 +3689,153 @@ objects:
         description: |
           Output only. The resource name of the Endpoint.
   
+
+    
+  - !ruby/object:Api::Resource
+    name: NasJobsNasTrialDetail
+    base_url: '{{parent}}/nasTrialDetails'
+    self_link: '{{name}}'
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation':
+      api: 'https://cloud.google.com/vertex-ai/docs'
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
+         path: 'name'
+         base_url: '{op_id}'
+         wait_ms: 1000
+      result: !ruby/object:Api::OpAsync::Result
+         path: 'response'
+         resource_inside_response: true
+      status: !ruby/object:Api::OpAsync::Status
+        path: 'done'
+        complete: True
+        allowed:
+          - True
+          - False
+      error: !ruby/object:Api::OpAsync::Error
+        path: 'error'
+        message: 'message'
+    description: |-
+        Represents a NasTrial details along with its parameters. If there is a corresponding train NasTrial, the train NasTrial is also returned.
+    properties:
+  
+      - !ruby/object:Api::Type::String
+        name: 'parameters'
+        description: |
+          The parameters for the NasJob NasTrial.
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+          Output only. Resource name of the NasTrialDetail.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'searchTrial'
+        description: |
+          Represents a uCAIP NasJob trial.
+        properties:
+            - !ruby/object:Api::Type::String
+              name: 'id'
+              description: |
+                Output only. The identifier of the NasTrial assigned by the service.
+            - !ruby/object:Api::Type::Enum
+              name: 'state'
+              description: |
+                Output only. The detailed state of the NasTrial.
+              values:
+                - :STATE_UNSPECIFIED
+                - :REQUESTED
+                - :ACTIVE
+                - :STOPPING
+                - :SUCCEEDED
+                - :INFEASIBLE
+            - !ruby/object:Api::Type::NestedObject
+              name: 'finalMeasurement'
+              description: |
+                A message representing a Measurement of a Trial. A Measurement contains the Metrics got by executing a Trial using suggested hyperparameter values.
+              properties:
+                  - !ruby/object:Api::Type::Array
+                    name: 'metrics'
+                    description: |
+                      Output only. A list of metrics got by evaluating the objective functions using suggested Parameter values.
+                    item_type: !ruby/object:Api::Type::NestedObject
+                      properties:
+                        - !ruby/object:Api::Type::String
+                          name: 'metricId'
+                          description: |
+                            Output only. The ID of the Metric. The Metric should be defined in StudySpec's Metrics.
+                        - !ruby/object:Api::Type::Integer
+                          name: 'value'
+                          description: |
+                            Output only. The value for this metric.
+                  - !ruby/object:Api::Type::String
+                    name: 'elapsedDuration'
+                    description: |
+                      Output only. Time that the Trial has been running at the point of this Measurement.
+                  - !ruby/object:Api::Type::String
+                    name: 'stepCount'
+                    description: |
+                      Output only. The number of steps the machine learning model has been trained for. Must be non-negative.
+            - !ruby/object:Api::Type::String
+              name: 'startTime'
+              description: |
+                Output only. Time when the NasTrial was started.
+            - !ruby/object:Api::Type::String
+              name: 'endTime'
+              description: |
+                Output only. Time when the NasTrial's status changed to `SUCCEEDED` or `INFEASIBLE`.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'trainTrial'
+        description: |
+          Represents a uCAIP NasJob trial.
+        properties:
+            - !ruby/object:Api::Type::String
+              name: 'id'
+              description: |
+                Output only. The identifier of the NasTrial assigned by the service.
+            - !ruby/object:Api::Type::Enum
+              name: 'state'
+              description: |
+                Output only. The detailed state of the NasTrial.
+              values:
+                - :STATE_UNSPECIFIED
+                - :REQUESTED
+                - :ACTIVE
+                - :STOPPING
+                - :SUCCEEDED
+                - :INFEASIBLE
+            - !ruby/object:Api::Type::NestedObject
+              name: 'finalMeasurement'
+              description: |
+                A message representing a Measurement of a Trial. A Measurement contains the Metrics got by executing a Trial using suggested hyperparameter values.
+              properties:
+                  - !ruby/object:Api::Type::Array
+                    name: 'metrics'
+                    description: |
+                      Output only. A list of metrics got by evaluating the objective functions using suggested Parameter values.
+                    item_type: !ruby/object:Api::Type::NestedObject
+                      properties:
+                        - !ruby/object:Api::Type::String
+                          name: 'metricId'
+                          description: |
+                            Output only. The ID of the Metric. The Metric should be defined in StudySpec's Metrics.
+                        - !ruby/object:Api::Type::Integer
+                          name: 'value'
+                          description: |
+                            Output only. The value for this metric.
+                  - !ruby/object:Api::Type::String
+                    name: 'elapsedDuration'
+                    description: |
+                      Output only. Time that the Trial has been running at the point of this Measurement.
+                  - !ruby/object:Api::Type::String
+                    name: 'stepCount'
+                    description: |
+                      Output only. The number of steps the machine learning model has been trained for. Must be non-negative.
+            - !ruby/object:Api::Type::String
+              name: 'startTime'
+              description: |
+                Output only. Time when the NasTrial was started.
+            - !ruby/object:Api::Type::String
+              name: 'endTime'
+              description: |
+                Output only. Time when the NasTrial's status changed to `SUCCEEDED` or `INFEASIBLE`.
+  

--- a/mmv1/templates/inspec/examples/google_vertex_ai_nas_jobs_nas_trial_detail/google_vertex_ai_nas_jobs_nas_trial_detail.erb
+++ b/mmv1/templates/inspec/examples/google_vertex_ai_nas_jobs_nas_trial_detail/google_vertex_ai_nas_jobs_nas_trial_detail.erb
@@ -1,0 +1,12 @@
+<% gcp_project_id = "#{external_attribute(pwd, 'gcp_project_id', doc_generation)}" -%>
+<% nas_jobs_nas_trial_detail = grab_attributes(pwd)['nas_jobs_nas_trial_detail'] -%>
+describe google_vertex_ai_nas_jobs_nas_trial_detail(name: "projects/#{gcp_project_id}/locations/#{nas_jobs_nas_trial_detail['region']}/nasJobs/#{nas_jobs_nas_trial_detail['nasJob']}/nasTrialDetails/#{nas_jobs_nas_trial_detail['name']}", region: <%= doc_generation ? "' #{nas_jobs_nas_trial_detail['region']}'":"nas_jobs_nas_trial_detail['region']" -%>) do
+	it { should exist }
+	its('parameters') { should cmp <%= doc_generation ? "'#{nas_jobs_nas_trial_detail['parameters']}'" : "nas_jobs_nas_trial_detail['parameters']" -%> }
+	its('name') { should cmp <%= doc_generation ? "'#{nas_jobs_nas_trial_detail['name']}'" : "nas_jobs_nas_trial_detail['name']" -%> }
+
+end
+
+describe google_vertex_ai_nas_jobs_nas_trial_detail(name: "does_not_exit", region: <%= doc_generation ? "' #{nas_jobs_nas_trial_detail['region']}'":"nas_jobs_nas_trial_detail['region']" -%>) do
+	it { should_not exist }
+end

--- a/mmv1/templates/inspec/examples/google_vertex_ai_nas_jobs_nas_trial_detail/google_vertex_ai_nas_jobs_nas_trial_detail_attributes.erb
+++ b/mmv1/templates/inspec/examples/google_vertex_ai_nas_jobs_nas_trial_detail/google_vertex_ai_nas_jobs_nas_trial_detail_attributes.erb
@@ -1,0 +1,3 @@
+gcp_project_id = input(:gcp_project_id, value: '<%= external_attribute(pwd, 'gcp_project_id') -%>', description: 'The GCP project identifier.')
+
+  nas_jobs_nas_trial_detail = input('nas_jobs_nas_trial_detail', value: <%= JSON.pretty_generate(grab_attributes(pwd)['nas_jobs_nas_trial_detail']) -%>, description: 'nas_jobs_nas_trial_detail description')

--- a/mmv1/templates/inspec/examples/google_vertex_ai_nas_jobs_nas_trial_detail/google_vertex_ai_nas_jobs_nas_trial_details.erb
+++ b/mmv1/templates/inspec/examples/google_vertex_ai_nas_jobs_nas_trial_detail/google_vertex_ai_nas_jobs_nas_trial_details.erb
@@ -1,0 +1,5 @@
+<% gcp_project_id = "#{external_attribute(pwd, 'gcp_project_id', doc_generation)}" -%>
+  <% nas_jobs_nas_trial_detail = grab_attributes(pwd)['nas_jobs_nas_trial_detail'] -%>
+  describe google_vertex_ai_nas_jobs_nas_trial_details(parent: "projects/#{gcp_project_id}/locations/#{nas_jobs_nas_trial_detail['region']}/nasJobs/#{nas_jobs_nas_trial_detail['nasJob']}", region: <%= doc_generation ? "' #{nas_jobs_nas_trial_detail['region']}'":"nas_jobs_nas_trial_detail['region']" -%>) do
+    it { should exist }
+  end

--- a/mmv1/templates/inspec/tests/integration/configuration/mm-attributes.yml
+++ b/mmv1/templates/inspec/tests/integration/configuration/mm-attributes.yml
@@ -600,7 +600,8 @@ endpoint:
   create_time : "value_createtime"
 
 nas_jobs_nas_trial_detail:
-  name : "value_name"
-  region : "value_region"
-  parent : "value_parent"
+  name : "1"
+  region : "us-central1"
+  nasJob: "3217974009958236160"
+  parent : "projects/ppradhan/locations/us-central1/nasJobs/3217974009958236160/nasTrialDetails/"
   parameters : "value_parameters"

--- a/mmv1/templates/inspec/tests/integration/configuration/mm-attributes.yml
+++ b/mmv1/templates/inspec/tests/integration/configuration/mm-attributes.yml
@@ -598,3 +598,9 @@ endpoint:
   display_name : "value_displayname"
   etag : "value_etag"
   create_time : "value_createtime"
+
+nas_jobs_nas_trial_detail:
+  name : "value_name"
+  region : "value_region"
+  parent : "value_parent"
+  parameters : "value_parameters"


### PR DESCRIPTION
Automatically generated by magic modules for service: vertex_ai and resource: NasJobs__nasTrialDetail.
This commit includes the following changes:
- Singular Resource ERB File
- Plural Resource ERB File 
- Terraform configuration
- api.yaml configuration for product vertex_ai and resource NasJobs__nasTrialDetail