### PR TITLE
CHEF-5553-MAGIC-MODULE-vertex_ai-Datasets__annotationSpec - Resource Implementation

### DIFF
--- a/mmv1/products/vertexai/api.yaml
+++ b/mmv1/products/vertexai/api.yaml
@@ -3689,3 +3689,54 @@ objects:
         description: |
           Output only. The resource name of the Endpoint.
   
+
+    
+  - !ruby/object:Api::Resource
+    name: DatasetsAnnotationSpec
+    self_link: '{{name}}'
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation':
+      api: 'https://cloud.google.com/vertex-ai/docs'
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
+         path: 'name'
+         base_url: '{op_id}'
+         wait_ms: 1000
+      result: !ruby/object:Api::OpAsync::Result
+         path: 'response'
+         resource_inside_response: true
+      status: !ruby/object:Api::OpAsync::Status
+        path: 'done'
+        complete: True
+        allowed:
+          - True
+          - False
+      error: !ruby/object:Api::OpAsync::Error
+        path: 'error'
+        message: 'message'
+    description: |-
+        Identifies a concept with which DataItems may be annotated with.
+    properties:
+  
+      - !ruby/object:Api::Type::String
+        name: 'displayName'
+        description: |
+          Required. The user-defined name of the AnnotationSpec. The name can be up to 128 characters long and can consist of any UTF-8 characters.
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+          Output only. Resource name of the AnnotationSpec.
+      - !ruby/object:Api::Type::String
+        name: 'etag'
+        description: |
+          Optional. Used to perform consistent read-modify-write updates. If not set, a blind "overwrite" update happens.
+      - !ruby/object:Api::Type::String
+        name: 'createTime'
+        description: |
+          Output only. Timestamp when this AnnotationSpec was created.
+      - !ruby/object:Api::Type::String
+        name: 'updateTime'
+        description: |
+          Output only. Timestamp when AnnotationSpec was last updated.
+  

--- a/mmv1/products/vertexai/inspec.yaml
+++ b/mmv1/products/vertexai/inspec.yaml
@@ -13,3 +13,6 @@
 
 --- !ruby/object:Provider::Inspec::Config
 overrides: !ruby/object:Overrides::ResourceOverrides
+  DatasetsAnnotationSpec: !ruby/object:Overrides::Inspec::ResourceOverride
+    singular_only: true
+

--- a/mmv1/templates/inspec/examples/google_vertex_ai_datasets_annotation_spec/google_vertex_ai_datasets_annotation_spec.erb
+++ b/mmv1/templates/inspec/examples/google_vertex_ai_datasets_annotation_spec/google_vertex_ai_datasets_annotation_spec.erb
@@ -1,0 +1,15 @@
+<% gcp_project_id = "#{external_attribute(pwd, 'gcp_project_id', doc_generation)}" -%>
+<% datasets_annotation_spec = grab_attributes(pwd)['datasets_annotation_spec'] -%>
+describe google_vertex_ai_datasets_annotation_spec(name: "projects/#{gcp_project_id}/locations/#{datasets_annotation_spec['region']}/datasets/#{datasets_annotation_spec['dataset']}/annotationSpecs/#{datasets_annotation_spec['name']}", region: <%= doc_generation ? "' #{datasets_annotation_spec['region']}'":"datasets_annotation_spec['region']" -%>) do
+	it { should exist }
+	its('display_name') { should cmp <%= doc_generation ? "'#{datasets_annotation_spec['display_name']}'" : "datasets_annotation_spec['display_name']" -%> }
+	its('name') { should cmp <%= doc_generation ? "'#{datasets_annotation_spec['name']}'" : "datasets_annotation_spec['name']" -%> }
+	its('etag') { should cmp <%= doc_generation ? "'#{datasets_annotation_spec['etag']}'" : "datasets_annotation_spec['etag']" -%> }
+	its('create_time') { should cmp <%= doc_generation ? "'#{datasets_annotation_spec['create_time']}'" : "datasets_annotation_spec['create_time']" -%> }
+	its('update_time') { should cmp <%= doc_generation ? "'#{datasets_annotation_spec['update_time']}'" : "datasets_annotation_spec['update_time']" -%> }
+
+end
+
+describe google_vertex_ai_datasets_annotation_spec(name: "does_not_exit", region: <%= doc_generation ? "' #{datasets_annotation_spec['region']}'":"datasets_annotation_spec['region']" -%>) do
+	it { should_not exist }
+end

--- a/mmv1/templates/inspec/examples/google_vertex_ai_datasets_annotation_spec/google_vertex_ai_datasets_annotation_spec_attributes.erb
+++ b/mmv1/templates/inspec/examples/google_vertex_ai_datasets_annotation_spec/google_vertex_ai_datasets_annotation_spec_attributes.erb
@@ -1,0 +1,3 @@
+gcp_project_id = input(:gcp_project_id, value: '<%= external_attribute(pwd, 'gcp_project_id') -%>', description: 'The GCP project identifier.')
+
+  datasets_annotation_spec = input('datasets_annotation_spec', value: <%= JSON.pretty_generate(grab_attributes(pwd)['datasets_annotation_spec']) -%>, description: 'datasets_annotation_spec description')

--- a/mmv1/templates/inspec/tests/integration/configuration/mm-attributes.yml
+++ b/mmv1/templates/inspec/tests/integration/configuration/mm-attributes.yml
@@ -600,10 +600,11 @@ endpoint:
   create_time : "value_createtime"
 
 datasets_annotation_spec:
-  name : "inspec-annotation-test"
+  name : "5438527833485869056"
   region : "us-central1"
-  dataset: "e2e-text-dataset-unique"
-  display_name : "value_displayname"
+  dataset: "1044994542735982592"
+  parent: "projects/165434197229/locations/us-central1/datasets/1044994542735982592/annotationSpecs/"
+  display_name : "InSpec"
   etag : "value_etag"
   create_time : "value_createtime"
   update_time : "value_updatetime"

--- a/mmv1/templates/inspec/tests/integration/configuration/mm-attributes.yml
+++ b/mmv1/templates/inspec/tests/integration/configuration/mm-attributes.yml
@@ -600,8 +600,9 @@ endpoint:
   create_time : "value_createtime"
 
 datasets_annotation_spec:
-  name : "value_name"
-  region : "value_region"
+  name : "inspec-annotation-test"
+  region : "us-central1"
+  dataset: "e2e-text-dataset-unique"
   display_name : "value_displayname"
   etag : "value_etag"
   create_time : "value_createtime"

--- a/mmv1/templates/inspec/tests/integration/configuration/mm-attributes.yml
+++ b/mmv1/templates/inspec/tests/integration/configuration/mm-attributes.yml
@@ -598,3 +598,11 @@ endpoint:
   display_name : "value_displayname"
   etag : "value_etag"
   create_time : "value_createtime"
+
+datasets_annotation_spec:
+  name : "value_name"
+  region : "value_region"
+  display_name : "value_displayname"
+  etag : "value_etag"
+  create_time : "value_createtime"
+  update_time : "value_updatetime"


### PR DESCRIPTION
Automatically generated by magic modules for service: vertex_ai and resource: Datasets__annotationSpec.
This commit includes the following changes:
- Singular Resource ERB File
- Plural Resource ERB File 
- Terraform configuration
- api.yaml configuration for product vertex_ai and resource Datasets__annotationSpec