### PR TITLE
CHEF-5554-MAGIC-MODULE-vertex_ai-Datasets__dataItem - Resource Implementation

### DIFF
--- a/mmv1/products/vertexai/api.yaml
+++ b/mmv1/products/vertexai/api.yaml
@@ -3689,3 +3689,62 @@ objects:
         description: |
           Output only. The resource name of the Endpoint.
   
+
+    
+  - !ruby/object:Api::Resource
+    name: DatasetsDataItem
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation':
+      api: 'https://cloud.google.com/vertex-ai/docs'
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
+         path: 'name'
+         base_url: '{op_id}'
+         wait_ms: 1000
+      result: !ruby/object:Api::OpAsync::Result
+         path: 'response'
+         resource_inside_response: true
+      status: !ruby/object:Api::OpAsync::Status
+        path: 'done'
+        complete: True
+        allowed:
+          - True
+          - False
+      error: !ruby/object:Api::OpAsync::Error
+        path: 'error'
+        message: 'message'
+    description: |-
+        A piece of data in a Dataset. Could be an image, a video, a document or plain text.
+    properties:
+  
+      - !ruby/object:Api::Type::String
+        name: 'updateTime'
+        description: |
+          Output only. Timestamp when this DataItem was last updated.
+      - !ruby/object:Api::Type::String
+        name: 'etag'
+        description: |
+          Optional. Used to perform consistent read-modify-write updates. If not set, a blind "overwrite" update happens.
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+          Output only. The resource name of the DataItem.
+      - !ruby/object:Api::Type::String
+        name: 'createTime'
+        description: |
+          Output only. Timestamp when this DataItem was created.
+      - !ruby/object:Api::Type::String
+        name: 'payload'
+        description: |
+          Required. The data that the DataItem represents (for example, an image or a text snippet). The schema of the payload is stored in the parent Dataset's metadata schema's dataItemSchemaUri field.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'labels'
+        description: |
+          Optional. The labels with user-defined metadata to organize your DataItems. Label keys and values can be no longer than 64 characters (Unicode codepoints), can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. No more than 64 user labels can be associated with one DataItem(System labels are excluded). See https://goo.gl/xmQnxf for more information and examples of labels. System reserved label keys are prefixed with "aiplatform.googleapis.com/" and are immutable.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'additionalProperties'
+            description: |
+              
+  

--- a/mmv1/templates/inspec/examples/google_vertex_ai_datasets_data_item/google_vertex_ai_datasets_data_item.erb
+++ b/mmv1/templates/inspec/examples/google_vertex_ai_datasets_data_item/google_vertex_ai_datasets_data_item.erb
@@ -1,0 +1,14 @@
+<% gcp_project_id = "#{external_attribute(pwd, 'gcp_project_id', doc_generation)}" -%>
+<% datasets_data_item = grab_attributes(pwd)['datasets_data_item'] -%>
+describe google_vertex_ai_datasets_data_item(name: "projects/#{gcp_project_id}/locations/#{datasets_data_item['region']}/datasets/#{datasets_data_item['dataset']}/annotationSpecs/#{datasets_data_item['annotationSpec']}", region: <%= doc_generation ? "' #{datasets_data_item['region']}'":"datasets_data_item['region']" -%>) do
+	it { should exist }
+	its('update_time') { should cmp <%= doc_generation ? "'#{datasets_data_item['update_time']}'" : "datasets_data_item['update_time']" -%> }
+	its('etag') { should cmp <%= doc_generation ? "'#{datasets_data_item['etag']}'" : "datasets_data_item['etag']" -%> }
+	its('name') { should cmp <%= doc_generation ? "'#{datasets_data_item['name']}'" : "datasets_data_item['name']" -%> }
+	its('create_time') { should cmp <%= doc_generation ? "'#{datasets_data_item['create_time']}'" : "datasets_data_item['create_time']" -%> }
+
+end
+
+describe google_vertex_ai_datasets_data_item(name: "does_not_exit", region: <%= doc_generation ? "' #{datasets_data_item['region']}'":"datasets_data_item['region']" -%>) do
+	it { should_not exist }
+end

--- a/mmv1/templates/inspec/examples/google_vertex_ai_datasets_data_item/google_vertex_ai_datasets_data_item_attributes.erb
+++ b/mmv1/templates/inspec/examples/google_vertex_ai_datasets_data_item/google_vertex_ai_datasets_data_item_attributes.erb
@@ -1,0 +1,3 @@
+gcp_project_id = input(:gcp_project_id, value: '<%= external_attribute(pwd, 'gcp_project_id') -%>', description: 'The GCP project identifier.')
+
+  datasets_data_item = input('datasets_data_item', value: <%= JSON.pretty_generate(grab_attributes(pwd)['datasets_data_item']) -%>, description: 'datasets_data_item description')

--- a/mmv1/templates/inspec/tests/integration/configuration/mm-attributes.yml
+++ b/mmv1/templates/inspec/tests/integration/configuration/mm-attributes.yml
@@ -598,3 +598,10 @@ endpoint:
   display_name : "value_displayname"
   etag : "value_etag"
   create_time : "value_createtime"
+
+datasets_data_item:
+  name : "value_name"
+  region : "value_region"
+  update_time : "value_updatetime"
+  etag : "value_etag"
+  create_time : "value_createtime"


### PR DESCRIPTION
Automatically generated by magic modules for service: vertex_ai and resource: Datasets__dataItem.
This commit includes the following changes:
- Singular Resource ERB File
- Plural Resource ERB File 
- Terraform configuration
- api.yaml configuration for product vertex_ai and resource Datasets__dataItem