### PR TITLE
aa-MAGIC-MODULE-vertex_ai-Tensorboards__experiment - Resource Implementation

### DIFF
--- a/mmv1/products/vertexai/api.yaml
+++ b/mmv1/products/vertexai/api.yaml
@@ -3689,3 +3689,141 @@ objects:
         description: |
           Output only. The resource name of the Endpoint.
   
+
+    
+  - !ruby/object:Api::Resource
+    name: TensorboardsExperiment
+    base_url: '{{parent}}/experiments'
+    self_link: '{{name}}'
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation':
+      api: 'https://cloud.google.com/vertex-ai/docs'
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
+         path: 'name'
+         base_url: '{op_id}'
+         wait_ms: 1000
+      result: !ruby/object:Api::OpAsync::Result
+         path: 'response'
+         resource_inside_response: true
+      status: !ruby/object:Api::OpAsync::Status
+        path: 'done'
+        complete: True
+        allowed:
+          - True
+          - False
+      error: !ruby/object:Api::OpAsync::Error
+        path: 'error'
+        message: 'message'
+    description: |-
+        A TensorboardExperiment is a group of TensorboardRuns, that are typically the results of a training job run, in a Tensorboard.
+    properties:
+  
+      - !ruby/object:Api::Type::String
+        name: 'description'
+        description: |
+          Description of this TensorboardExperiment.
+      - !ruby/object:Api::Type::String
+        name: 'source'
+        description: |
+          Immutable. Source of the TensorboardExperiment. Example: a custom training job.
+      - !ruby/object:Api::Type::String
+        name: 'displayName'
+        description: |
+          User provided name of this TensorboardExperiment.
+      - !ruby/object:Api::Type::String
+        name: 'createTime'
+        description: |
+          Output only. Timestamp when this TensorboardExperiment was created.
+      - !ruby/object:Api::Type::String
+        name: 'updateTime'
+        description: |
+          Output only. Timestamp when this TensorboardExperiment was last updated.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'labels'
+        description: |
+          The labels with user-defined metadata to organize your TensorboardExperiment. Label keys and values cannot be longer than 64 characters (Unicode codepoints), can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. No more than 64 user labels can be associated with one Dataset (System labels are excluded). See https://goo.gl/xmQnxf for more information and examples of labels. System reserved label keys are prefixed with `aiplatform.googleapis.com/` and are immutable. The following system labels exist for each Dataset: * `aiplatform.googleapis.com/dataset_metadata_schema`: output only. Its value is the metadata_schema's title.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'additionalProperties'
+            description: |
+              
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+          Output only. Name of the TensorboardExperiment. Format: `projects/{project}/locations/{location}/tensorboards/{tensorboard}/experiments/{experiment}`
+      - !ruby/object:Api::Type::String
+        name: 'etag'
+        description: |
+          Used to perform consistent read-modify-write updates. If not set, a blind "overwrite" update happens.
+  
+
+    
+  - !ruby/object:Api::Resource
+    name: TensorboardsExperiment
+    base_url: '{{parent}}/experiments'
+    self_link: '{{name}}'
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation':
+      api: 'https://cloud.google.com/vertex-ai/docs'
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
+         path: 'name'
+         base_url: '{op_id}'
+         wait_ms: 1000
+      result: !ruby/object:Api::OpAsync::Result
+         path: 'response'
+         resource_inside_response: true
+      status: !ruby/object:Api::OpAsync::Status
+        path: 'done'
+        complete: True
+        allowed:
+          - True
+          - False
+      error: !ruby/object:Api::OpAsync::Error
+        path: 'error'
+        message: 'message'
+    description: |-
+        A TensorboardExperiment is a group of TensorboardRuns, that are typically the results of a training job run, in a Tensorboard.
+    properties:
+  
+      - !ruby/object:Api::Type::String
+        name: 'description'
+        description: |
+          Description of this TensorboardExperiment.
+      - !ruby/object:Api::Type::String
+        name: 'source'
+        description: |
+          Immutable. Source of the TensorboardExperiment. Example: a custom training job.
+      - !ruby/object:Api::Type::String
+        name: 'displayName'
+        description: |
+          User provided name of this TensorboardExperiment.
+      - !ruby/object:Api::Type::String
+        name: 'createTime'
+        description: |
+          Output only. Timestamp when this TensorboardExperiment was created.
+      - !ruby/object:Api::Type::String
+        name: 'updateTime'
+        description: |
+          Output only. Timestamp when this TensorboardExperiment was last updated.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'labels'
+        description: |
+          The labels with user-defined metadata to organize your TensorboardExperiment. Label keys and values cannot be longer than 64 characters (Unicode codepoints), can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. No more than 64 user labels can be associated with one Dataset (System labels are excluded). See https://goo.gl/xmQnxf for more information and examples of labels. System reserved label keys are prefixed with `aiplatform.googleapis.com/` and are immutable. The following system labels exist for each Dataset: * `aiplatform.googleapis.com/dataset_metadata_schema`: output only. Its value is the metadata_schema's title.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'additionalProperties'
+            description: |
+              
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+          Output only. Name of the TensorboardExperiment. Format: `projects/{project}/locations/{location}/tensorboards/{tensorboard}/experiments/{experiment}`
+      - !ruby/object:Api::Type::String
+        name: 'etag'
+        description: |
+          Used to perform consistent read-modify-write updates. If not set, a blind "overwrite" update happens.
+  

--- a/mmv1/templates/inspec/examples/google_vertex_ai_tensorboards_experiment/google_vertex_ai_tensorboards_experiment.erb
+++ b/mmv1/templates/inspec/examples/google_vertex_ai_tensorboards_experiment/google_vertex_ai_tensorboards_experiment.erb
@@ -1,0 +1,17 @@
+<% gcp_project_id = "#{external_attribute(pwd, 'gcp_project_id', doc_generation)}" -%>
+<% tensorboards_experiment = grab_attributes(pwd)['tensorboards_experiment'] -%>
+describe google_vertex_ai_tensorboards_experiment(name: "projects/#{gcp_project_id}/locations/#{tensorboards_experiment['region']}/tensorboards/#{tensorboards_experiment['tensorboard']}/experiments/#{tensorboards_experiment['name']}", region: <%= doc_generation ? "' #{tensorboards_experiment['region']}'":"tensorboards_experiment['region']" -%>) do
+	it { should exist }
+	its('description') { should cmp <%= doc_generation ? "'#{tensorboards_experiment['description']}'" : "tensorboards_experiment['description']" -%> }
+	its('source') { should cmp <%= doc_generation ? "'#{tensorboards_experiment['source']}'" : "tensorboards_experiment['source']" -%> }
+	its('display_name') { should cmp <%= doc_generation ? "'#{tensorboards_experiment['display_name']}'" : "tensorboards_experiment['display_name']" -%> }
+	its('create_time') { should cmp <%= doc_generation ? "'#{tensorboards_experiment['create_time']}'" : "tensorboards_experiment['create_time']" -%> }
+	its('update_time') { should cmp <%= doc_generation ? "'#{tensorboards_experiment['update_time']}'" : "tensorboards_experiment['update_time']" -%> }
+	its('name') { should cmp <%= doc_generation ? "'#{tensorboards_experiment['name']}'" : "tensorboards_experiment['name']" -%> }
+	its('etag') { should cmp <%= doc_generation ? "'#{tensorboards_experiment['etag']}'" : "tensorboards_experiment['etag']" -%> }
+
+end
+
+describe google_vertex_ai_tensorboards_experiment(name: "does_not_exit", region: <%= doc_generation ? "' #{tensorboards_experiment['region']}'":"tensorboards_experiment['region']" -%>) do
+	it { should_not exist }
+end

--- a/mmv1/templates/inspec/examples/google_vertex_ai_tensorboards_experiment/google_vertex_ai_tensorboards_experiment_attributes.erb
+++ b/mmv1/templates/inspec/examples/google_vertex_ai_tensorboards_experiment/google_vertex_ai_tensorboards_experiment_attributes.erb
@@ -1,0 +1,3 @@
+gcp_project_id = input(:gcp_project_id, value: '<%= external_attribute(pwd, 'gcp_project_id') -%>', description: 'The GCP project identifier.')
+
+  tensorboards_experiment = input('tensorboards_experiment', value: <%= JSON.pretty_generate(grab_attributes(pwd)['tensorboards_experiment']) -%>, description: 'tensorboards_experiment description')

--- a/mmv1/templates/inspec/examples/google_vertex_ai_tensorboards_experiment/google_vertex_ai_tensorboards_experiments.erb
+++ b/mmv1/templates/inspec/examples/google_vertex_ai_tensorboards_experiment/google_vertex_ai_tensorboards_experiments.erb
@@ -1,0 +1,5 @@
+<% gcp_project_id = "#{external_attribute(pwd, 'gcp_project_id', doc_generation)}" -%>
+  <% tensorboards_experiment = grab_attributes(pwd)['tensorboards_experiment'] -%>
+  describe google_vertex_ai_tensorboards_experiments(parent: "projects/#{gcp_project_id}/locations/#{tensorboards_experiment['region']}/tensorboards/#{tensorboards_experiment['tensorboard']}", region: <%= doc_generation ? "' #{tensorboards_experiment['region']}'":"tensorboards_experiment['region']" -%>) do
+    it { should exist }
+  end

--- a/mmv1/templates/inspec/tests/integration/configuration/mm-attributes.yml
+++ b/mmv1/templates/inspec/tests/integration/configuration/mm-attributes.yml
@@ -598,3 +598,14 @@ endpoint:
   display_name : "value_displayname"
   etag : "value_etag"
   create_time : "value_createtime"
+
+tensorboards_experiment:
+  name : "value_name"
+  region : "value_region"
+  parent : "value_parent"
+  description : "value_description"
+  source : "value_source"
+  display_name : "value_displayname"
+  create_time : "value_createtime"
+  update_time : "value_updatetime"
+  etag : "value_etag"


### PR DESCRIPTION
Automatically generated by magic modules for service: vertex_ai and resource: Tensorboards__experiment.
This commit includes the following changes:
- Singular Resource ERB File
- Plural Resource ERB File 
- Terraform configuration
- api.yaml configuration for product vertex_ai and resource Tensorboards__experiment