### PR TITLE
CHEF-5565-MAGIC-MODULE-vertex_ai-MetadataStores__artifact - Resource Implementation

### DIFF
--- a/mmv1/products/vertexai/api.yaml
+++ b/mmv1/products/vertexai/api.yaml
@@ -3689,3 +3689,191 @@ objects:
         description: |
           Output only. The resource name of the Endpoint.
   
+
+    
+  - !ruby/object:Api::Resource
+    name: MetadataStoresArtifact
+    base_url: '{{parent}}/artifacts'
+    self_link: '{{name}}'
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation':
+      api: 'https://cloud.google.com/vertex-ai/docs'
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
+         path: 'name'
+         base_url: '{op_id}'
+         wait_ms: 1000
+      result: !ruby/object:Api::OpAsync::Result
+         path: 'response'
+         resource_inside_response: true
+      status: !ruby/object:Api::OpAsync::Status
+        path: 'done'
+        complete: True
+        allowed:
+          - True
+          - False
+      error: !ruby/object:Api::OpAsync::Error
+        path: 'error'
+        message: 'message'
+    description: |-
+        Instance of a general artifact.
+    properties:
+  
+      - !ruby/object:Api::Type::String
+        name: 'schemaVersion'
+        description: |
+          The version of the schema in schema_name to use. Schema title and version is expected to be registered in earlier Create Schema calls. And both are used together as unique identifiers to identify schemas within the local metadata store.
+      - !ruby/object:Api::Type::String
+        name: 'displayName'
+        description: |
+          User provided display name of the Artifact. May be up to 128 Unicode characters.
+      - !ruby/object:Api::Type::String
+        name: 'etag'
+        description: |
+          An eTag used to perform consistent read-modify-write updates. If not set, a blind "overwrite" update happens.
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+          Output only. The resource name of the Artifact.
+      - !ruby/object:Api::Type::String
+        name: 'updateTime'
+        description: |
+          Output only. Timestamp when this Artifact was last updated.
+      - !ruby/object:Api::Type::Enum
+        name: 'state'
+        description: |
+          The state of this Artifact. This is a property of the Artifact, and does not imply or capture any ongoing process. This property is managed by clients (such as Vertex AI Pipelines), and the system does not prescribe or check the validity of state transitions.
+        values:
+          - :STATE_UNSPECIFIED
+          - :PENDING
+          - :LIVE
+      - !ruby/object:Api::Type::NestedObject
+        name: 'metadata'
+        description: |
+          Properties of the Artifact. Top level metadata keys' heading and trailing spaces will be trimmed. The size of this field should not exceed 200KB.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'additionalProperties'
+            description: |
+              Properties of the object.
+      - !ruby/object:Api::Type::String
+        name: 'uri'
+        description: |
+          The uniform resource identifier of the artifact file. May be empty if there is no actual artifact file.
+      - !ruby/object:Api::Type::String
+        name: 'createTime'
+        description: |
+          Output only. Timestamp when this Artifact was created.
+      - !ruby/object:Api::Type::String
+        name: 'schemaTitle'
+        description: |
+          The title of the schema describing the metadata. Schema title and version is expected to be registered in earlier Create Schema calls. And both are used together as unique identifiers to identify schemas within the local metadata store.
+      - !ruby/object:Api::Type::String
+        name: 'description'
+        description: |
+          Description of the Artifact
+      - !ruby/object:Api::Type::NestedObject
+        name: 'labels'
+        description: |
+          The labels with user-defined metadata to organize your Artifacts. Label keys and values can be no longer than 64 characters (Unicode codepoints), can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. No more than 64 user labels can be associated with one Artifact (System labels are excluded).
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'additionalProperties'
+            description: |
+              
+  
+
+    
+  - !ruby/object:Api::Resource
+    name: MetadataStoresArtifact
+    base_url: '{{parent}}/artifacts'
+    self_link: '{{name}}'
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation':
+      api: 'https://cloud.google.com/vertex-ai/docs'
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
+         path: 'name'
+         base_url: '{op_id}'
+         wait_ms: 1000
+      result: !ruby/object:Api::OpAsync::Result
+         path: 'response'
+         resource_inside_response: true
+      status: !ruby/object:Api::OpAsync::Status
+        path: 'done'
+        complete: True
+        allowed:
+          - True
+          - False
+      error: !ruby/object:Api::OpAsync::Error
+        path: 'error'
+        message: 'message'
+    description: |-
+        Instance of a general artifact.
+    properties:
+  
+      - !ruby/object:Api::Type::String
+        name: 'schemaVersion'
+        description: |
+          The version of the schema in schema_name to use. Schema title and version is expected to be registered in earlier Create Schema calls. And both are used together as unique identifiers to identify schemas within the local metadata store.
+      - !ruby/object:Api::Type::String
+        name: 'displayName'
+        description: |
+          User provided display name of the Artifact. May be up to 128 Unicode characters.
+      - !ruby/object:Api::Type::String
+        name: 'etag'
+        description: |
+          An eTag used to perform consistent read-modify-write updates. If not set, a blind "overwrite" update happens.
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+          Output only. The resource name of the Artifact.
+      - !ruby/object:Api::Type::String
+        name: 'updateTime'
+        description: |
+          Output only. Timestamp when this Artifact was last updated.
+      - !ruby/object:Api::Type::Enum
+        name: 'state'
+        description: |
+          The state of this Artifact. This is a property of the Artifact, and does not imply or capture any ongoing process. This property is managed by clients (such as Vertex AI Pipelines), and the system does not prescribe or check the validity of state transitions.
+        values:
+          - :STATE_UNSPECIFIED
+          - :PENDING
+          - :LIVE
+      - !ruby/object:Api::Type::NestedObject
+        name: 'metadata'
+        description: |
+          Properties of the Artifact. Top level metadata keys' heading and trailing spaces will be trimmed. The size of this field should not exceed 200KB.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'additionalProperties'
+            description: |
+              Properties of the object.
+      - !ruby/object:Api::Type::String
+        name: 'uri'
+        description: |
+          The uniform resource identifier of the artifact file. May be empty if there is no actual artifact file.
+      - !ruby/object:Api::Type::String
+        name: 'createTime'
+        description: |
+          Output only. Timestamp when this Artifact was created.
+      - !ruby/object:Api::Type::String
+        name: 'schemaTitle'
+        description: |
+          The title of the schema describing the metadata. Schema title and version is expected to be registered in earlier Create Schema calls. And both are used together as unique identifiers to identify schemas within the local metadata store.
+      - !ruby/object:Api::Type::String
+        name: 'description'
+        description: |
+          Description of the Artifact
+      - !ruby/object:Api::Type::NestedObject
+        name: 'labels'
+        description: |
+          The labels with user-defined metadata to organize your Artifacts. Label keys and values can be no longer than 64 characters (Unicode codepoints), can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. No more than 64 user labels can be associated with one Artifact (System labels are excluded).
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'additionalProperties'
+            description: |
+              
+  

--- a/mmv1/templates/inspec/examples/google_vertex_ai_metadata_stores_artifact/google_vertex_ai_metadata_stores_artifact.erb
+++ b/mmv1/templates/inspec/examples/google_vertex_ai_metadata_stores_artifact/google_vertex_ai_metadata_stores_artifact.erb
@@ -1,0 +1,20 @@
+<% gcp_project_id = "#{external_attribute(pwd, 'gcp_project_id', doc_generation)}" -%>
+<% metadata_stores_artifact = grab_attributes(pwd)['metadata_stores_artifact'] -%>
+describe google_vertex_ai_metadata_stores_artifact(name: "projects/#{gcp_project_id}/locations/#{metadata_stores_artifact['region']}/metadataStores/#{metadata_stores_artifact['metadataStore']}/artifacts/#{metadata_stores_artifact['name']}", region: <%= doc_generation ? "' #{metadata_stores_artifact['region']}'":"metadata_stores_artifact['region']" -%>) do
+	it { should exist }
+	its('schema_version') { should cmp <%= doc_generation ? "'#{metadata_stores_artifact['schema_version']}'" : "metadata_stores_artifact['schema_version']" -%> }
+	its('display_name') { should cmp <%= doc_generation ? "'#{metadata_stores_artifact['display_name']}'" : "metadata_stores_artifact['display_name']" -%> }
+	its('etag') { should cmp <%= doc_generation ? "'#{metadata_stores_artifact['etag']}'" : "metadata_stores_artifact['etag']" -%> }
+	its('name') { should cmp <%= doc_generation ? "'#{metadata_stores_artifact['name']}'" : "metadata_stores_artifact['name']" -%> }
+	its('update_time') { should cmp <%= doc_generation ? "'#{metadata_stores_artifact['update_time']}'" : "metadata_stores_artifact['update_time']" -%> }
+	its('state') { should cmp <%= doc_generation ? "'#{metadata_stores_artifact['state']}'" : "metadata_stores_artifact['state']" -%> }
+	its('uri') { should cmp <%= doc_generation ? "'#{metadata_stores_artifact['uri']}'" : "metadata_stores_artifact['uri']" -%> }
+	its('create_time') { should cmp <%= doc_generation ? "'#{metadata_stores_artifact['create_time']}'" : "metadata_stores_artifact['create_time']" -%> }
+	its('schema_title') { should cmp <%= doc_generation ? "'#{metadata_stores_artifact['schema_title']}'" : "metadata_stores_artifact['schema_title']" -%> }
+	its('description') { should cmp <%= doc_generation ? "'#{metadata_stores_artifact['description']}'" : "metadata_stores_artifact['description']" -%> }
+
+end
+
+describe google_vertex_ai_metadata_stores_artifact(name: "does_not_exit", region: <%= doc_generation ? "' #{metadata_stores_artifact['region']}'":"metadata_stores_artifact['region']" -%>) do
+	it { should_not exist }
+end

--- a/mmv1/templates/inspec/examples/google_vertex_ai_metadata_stores_artifact/google_vertex_ai_metadata_stores_artifact_attributes.erb
+++ b/mmv1/templates/inspec/examples/google_vertex_ai_metadata_stores_artifact/google_vertex_ai_metadata_stores_artifact_attributes.erb
@@ -1,0 +1,3 @@
+gcp_project_id = input(:gcp_project_id, value: '<%= external_attribute(pwd, 'gcp_project_id') -%>', description: 'The GCP project identifier.')
+
+  metadata_stores_artifact = input('metadata_stores_artifact', value: <%= JSON.pretty_generate(grab_attributes(pwd)['metadata_stores_artifact']) -%>, description: 'metadata_stores_artifact description')

--- a/mmv1/templates/inspec/examples/google_vertex_ai_metadata_stores_artifact/google_vertex_ai_metadata_stores_artifacts.erb
+++ b/mmv1/templates/inspec/examples/google_vertex_ai_metadata_stores_artifact/google_vertex_ai_metadata_stores_artifacts.erb
@@ -1,0 +1,5 @@
+<% gcp_project_id = "#{external_attribute(pwd, 'gcp_project_id', doc_generation)}" -%>
+  <% metadata_stores_artifact = grab_attributes(pwd)['metadata_stores_artifact'] -%>
+  describe google_vertex_ai_metadata_stores_artifacts(parent: "projects/#{gcp_project_id}/locations/#{metadata_stores_artifact['region']}/metadataStores/#{metadata_stores_artifact['metadataStore']}", region: <%= doc_generation ? "' #{metadata_stores_artifact['region']}'":"metadata_stores_artifact['region']" -%>) do
+    it { should exist }
+  end

--- a/mmv1/templates/inspec/tests/integration/configuration/mm-attributes.yml
+++ b/mmv1/templates/inspec/tests/integration/configuration/mm-attributes.yml
@@ -600,9 +600,10 @@ endpoint:
   create_time : "value_createtime"
 
 metadata_stores_artifact:
-  name : "value_name"
-  region : "value_region"
-  parent : "value_parent"
+  name : "2811503570633325756"
+  region : "us-central1"
+  parent : "projects/165434197229/locations/us-central1/metadataStores/default/artifacts/"
+  metadataStore: "default"
   schema_version : "value_schemaversion"
   display_name : "value_displayname"
   etag : "value_etag"

--- a/mmv1/templates/inspec/tests/integration/configuration/mm-attributes.yml
+++ b/mmv1/templates/inspec/tests/integration/configuration/mm-attributes.yml
@@ -598,3 +598,17 @@ endpoint:
   display_name : "value_displayname"
   etag : "value_etag"
   create_time : "value_createtime"
+
+metadata_stores_artifact:
+  name : "value_name"
+  region : "value_region"
+  parent : "value_parent"
+  schema_version : "value_schemaversion"
+  display_name : "value_displayname"
+  etag : "value_etag"
+  update_time : "value_updatetime"
+  state : "value_state"
+  uri : "value_uri"
+  create_time : "value_createtime"
+  schema_title : "value_schematitle"
+  description : "value_description"


### PR DESCRIPTION
Automatically generated by magic modules for service: vertex_ai and resource: MetadataStores__artifact.
This commit includes the following changes:
- Singular Resource ERB File
- Plural Resource ERB File 
- Terraform configuration
- api.yaml configuration for product vertex_ai and resource MetadataStores__artifact