### PR TITLE
CHEF-5566-MAGIC-MODULE-vertex_ai-MetadataStores__context - Resource Implementation

### DIFF
--- a/mmv1/products/vertexai/api.yaml
+++ b/mmv1/products/vertexai/api.yaml
@@ -3689,3 +3689,177 @@ objects:
         description: |
           Output only. The resource name of the Endpoint.
   
+
+    
+  - !ruby/object:Api::Resource
+    name: MetadataStoresContext
+    base_url: '{{parent}}/contexts'
+    self_link: '{{name}}'
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation':
+      api: 'https://cloud.google.com/vertex-ai/docs'
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
+         path: 'name'
+         base_url: '{op_id}'
+         wait_ms: 1000
+      result: !ruby/object:Api::OpAsync::Result
+         path: 'response'
+         resource_inside_response: true
+      status: !ruby/object:Api::OpAsync::Status
+        path: 'done'
+        complete: True
+        allowed:
+          - True
+          - False
+      error: !ruby/object:Api::OpAsync::Error
+        path: 'error'
+        message: 'message'
+    description: |-
+        Instance of a general context.
+    properties:
+  
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+          Immutable. The resource name of the Context.
+      - !ruby/object:Api::Type::String
+        name: 'schemaTitle'
+        description: |
+          The title of the schema describing the metadata. Schema title and version is expected to be registered in earlier Create Schema calls. And both are used together as unique identifiers to identify schemas within the local metadata store.
+      - !ruby/object:Api::Type::String
+        name: 'etag'
+        description: |
+          An eTag used to perform consistent read-modify-write updates. If not set, a blind "overwrite" update happens.
+      - !ruby/object:Api::Type::String
+        name: 'description'
+        description: |
+          Description of the Context
+      - !ruby/object:Api::Type::String
+        name: 'displayName'
+        description: |
+          User provided display name of the Context. May be up to 128 Unicode characters.
+      - !ruby/object:Api::Type::String
+        name: 'schemaVersion'
+        description: |
+          The version of the schema in schema_name to use. Schema title and version is expected to be registered in earlier Create Schema calls. And both are used together as unique identifiers to identify schemas within the local metadata store.
+      - !ruby/object:Api::Type::String
+        name: 'createTime'
+        description: |
+          Output only. Timestamp when this Context was created.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'labels'
+        description: |
+          The labels with user-defined metadata to organize your Contexts. Label keys and values can be no longer than 64 characters (Unicode codepoints), can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. No more than 64 user labels can be associated with one Context (System labels are excluded).
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'additionalProperties'
+            description: |
+              
+      - !ruby/object:Api::Type::NestedObject
+        name: 'metadata'
+        description: |
+          Properties of the Context. Top level metadata keys' heading and trailing spaces will be trimmed. The size of this field should not exceed 200KB.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'additionalProperties'
+            description: |
+              Properties of the object.
+      - !ruby/object:Api::Type::String
+        name: 'updateTime'
+        description: |
+          Output only. Timestamp when this Context was last updated.
+      - !ruby/object:Api::Type::Array
+        name: 'parentContexts'
+        description: |
+          Output only. A list of resource names of Contexts that are parents of this Context. A Context may have at most 10 parent_contexts.
+        item_type: Api::Type::String
+  
+
+    
+  - !ruby/object:Api::Resource
+    name: MetadataStoresContext
+    base_url: '{{parent}}/contexts'
+    self_link: '{{name}}'
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation':
+      api: 'https://cloud.google.com/vertex-ai/docs'
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
+         path: 'name'
+         base_url: '{op_id}'
+         wait_ms: 1000
+      result: !ruby/object:Api::OpAsync::Result
+         path: 'response'
+         resource_inside_response: true
+      status: !ruby/object:Api::OpAsync::Status
+        path: 'done'
+        complete: True
+        allowed:
+          - True
+          - False
+      error: !ruby/object:Api::OpAsync::Error
+        path: 'error'
+        message: 'message'
+    description: |-
+        Instance of a general context.
+    properties:
+  
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+          Immutable. The resource name of the Context.
+      - !ruby/object:Api::Type::String
+        name: 'schemaTitle'
+        description: |
+          The title of the schema describing the metadata. Schema title and version is expected to be registered in earlier Create Schema calls. And both are used together as unique identifiers to identify schemas within the local metadata store.
+      - !ruby/object:Api::Type::String
+        name: 'etag'
+        description: |
+          An eTag used to perform consistent read-modify-write updates. If not set, a blind "overwrite" update happens.
+      - !ruby/object:Api::Type::String
+        name: 'description'
+        description: |
+          Description of the Context
+      - !ruby/object:Api::Type::String
+        name: 'displayName'
+        description: |
+          User provided display name of the Context. May be up to 128 Unicode characters.
+      - !ruby/object:Api::Type::String
+        name: 'schemaVersion'
+        description: |
+          The version of the schema in schema_name to use. Schema title and version is expected to be registered in earlier Create Schema calls. And both are used together as unique identifiers to identify schemas within the local metadata store.
+      - !ruby/object:Api::Type::String
+        name: 'createTime'
+        description: |
+          Output only. Timestamp when this Context was created.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'labels'
+        description: |
+          The labels with user-defined metadata to organize your Contexts. Label keys and values can be no longer than 64 characters (Unicode codepoints), can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. No more than 64 user labels can be associated with one Context (System labels are excluded).
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'additionalProperties'
+            description: |
+              
+      - !ruby/object:Api::Type::NestedObject
+        name: 'metadata'
+        description: |
+          Properties of the Context. Top level metadata keys' heading and trailing spaces will be trimmed. The size of this field should not exceed 200KB.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'additionalProperties'
+            description: |
+              Properties of the object.
+      - !ruby/object:Api::Type::String
+        name: 'updateTime'
+        description: |
+          Output only. Timestamp when this Context was last updated.
+      - !ruby/object:Api::Type::Array
+        name: 'parentContexts'
+        description: |
+          Output only. A list of resource names of Contexts that are parents of this Context. A Context may have at most 10 parent_contexts.
+        item_type: Api::Type::String
+  

--- a/mmv1/templates/inspec/examples/google_vertex_ai_metadata_stores_context/google_vertex_ai_metadata_stores_context.erb
+++ b/mmv1/templates/inspec/examples/google_vertex_ai_metadata_stores_context/google_vertex_ai_metadata_stores_context.erb
@@ -1,0 +1,18 @@
+<% gcp_project_id = "#{external_attribute(pwd, 'gcp_project_id', doc_generation)}" -%>
+<% metadata_stores_context = grab_attributes(pwd)['metadata_stores_context'] -%>
+describe google_vertex_ai_metadata_stores_context(name: "projects/#{gcp_project_id}/locations/#{metadata_stores_context['region']}/metadataStores/#{metadata_stores_context['metadataStore']}/contexts/#{metadata_stores_context['name']}", region: <%= doc_generation ? "' #{metadata_stores_context['region']}'":"metadata_stores_context['region']" -%>) do
+	it { should exist }
+	its('name') { should cmp <%= doc_generation ? "'#{metadata_stores_context['name']}'" : "metadata_stores_context['name']" -%> }
+	its('schema_title') { should cmp <%= doc_generation ? "'#{metadata_stores_context['schema_title']}'" : "metadata_stores_context['schema_title']" -%> }
+	its('etag') { should cmp <%= doc_generation ? "'#{metadata_stores_context['etag']}'" : "metadata_stores_context['etag']" -%> }
+	its('description') { should cmp <%= doc_generation ? "'#{metadata_stores_context['description']}'" : "metadata_stores_context['description']" -%> }
+	its('display_name') { should cmp <%= doc_generation ? "'#{metadata_stores_context['display_name']}'" : "metadata_stores_context['display_name']" -%> }
+	its('schema_version') { should cmp <%= doc_generation ? "'#{metadata_stores_context['schema_version']}'" : "metadata_stores_context['schema_version']" -%> }
+	its('create_time') { should cmp <%= doc_generation ? "'#{metadata_stores_context['create_time']}'" : "metadata_stores_context['create_time']" -%> }
+	its('update_time') { should cmp <%= doc_generation ? "'#{metadata_stores_context['update_time']}'" : "metadata_stores_context['update_time']" -%> }
+
+end
+
+describe google_vertex_ai_metadata_stores_context(name: "does_not_exit", region: <%= doc_generation ? "' #{metadata_stores_context['region']}'":"metadata_stores_context['region']" -%>) do
+	it { should_not exist }
+end

--- a/mmv1/templates/inspec/examples/google_vertex_ai_metadata_stores_context/google_vertex_ai_metadata_stores_context_attributes.erb
+++ b/mmv1/templates/inspec/examples/google_vertex_ai_metadata_stores_context/google_vertex_ai_metadata_stores_context_attributes.erb
@@ -1,0 +1,3 @@
+gcp_project_id = input(:gcp_project_id, value: '<%= external_attribute(pwd, 'gcp_project_id') -%>', description: 'The GCP project identifier.')
+
+  metadata_stores_context = input('metadata_stores_context', value: <%= JSON.pretty_generate(grab_attributes(pwd)['metadata_stores_context']) -%>, description: 'metadata_stores_context description')

--- a/mmv1/templates/inspec/examples/google_vertex_ai_metadata_stores_context/google_vertex_ai_metadata_stores_contexts.erb
+++ b/mmv1/templates/inspec/examples/google_vertex_ai_metadata_stores_context/google_vertex_ai_metadata_stores_contexts.erb
@@ -1,0 +1,5 @@
+<% gcp_project_id = "#{external_attribute(pwd, 'gcp_project_id', doc_generation)}" -%>
+  <% metadata_stores_context = grab_attributes(pwd)['metadata_stores_context'] -%>
+  describe google_vertex_ai_metadata_stores_contexts(parent: "projects/#{gcp_project_id}/locations/#{metadata_stores_context['region']}/metadataStores/#{metadata_stores_context['metadataStore']}", region: <%= doc_generation ? "' #{metadata_stores_context['region']}'":"metadata_stores_context['region']" -%>) do
+    it { should exist }
+  end

--- a/mmv1/templates/inspec/tests/integration/configuration/mm-attributes.yml
+++ b/mmv1/templates/inspec/tests/integration/configuration/mm-attributes.yml
@@ -600,13 +600,14 @@ endpoint:
   create_time : "value_createtime"
 
 metadata_stores_context:
-  name : "value_name"
-  region : "value_region"
-  parent : "value_parent"
+  name : "autologging-experiment-w0apl7la-autologging-tf-experiment-w0apl7la"
+  region : "us-central1"
+  parent : "projects/165434197229/locations/us-central1/metadataStores/default/contexts/"
+  metadataStore: "default",
   schema_title : "value_schematitle"
   etag : "value_etag"
   description : "value_description"
-  display_name : "value_displayname"
+  display_name : "autologging-tf-experiment-w0apl7la"
   schema_version : "value_schemaversion"
   create_time : "value_createtime"
   update_time : "value_updatetime"

--- a/mmv1/templates/inspec/tests/integration/configuration/mm-attributes.yml
+++ b/mmv1/templates/inspec/tests/integration/configuration/mm-attributes.yml
@@ -598,3 +598,15 @@ endpoint:
   display_name : "value_displayname"
   etag : "value_etag"
   create_time : "value_createtime"
+
+metadata_stores_context:
+  name : "value_name"
+  region : "value_region"
+  parent : "value_parent"
+  schema_title : "value_schematitle"
+  etag : "value_etag"
+  description : "value_description"
+  display_name : "value_displayname"
+  schema_version : "value_schemaversion"
+  create_time : "value_createtime"
+  update_time : "value_updatetime"


### PR DESCRIPTION
Automatically generated by magic modules for service: vertex_ai and resource: MetadataStores__context.
This commit includes the following changes:
- Singular Resource ERB File
- Plural Resource ERB File 
- Terraform configuration
- api.yaml configuration for product vertex_ai and resource MetadataStores__context