### PR TITLE
CHEF-5568-MAGIC-MODULE-vertex_ai-MetadataStores__metadataSchema - Resource Implementation

### DIFF
--- a/mmv1/products/vertexai/api.yaml
+++ b/mmv1/products/vertexai/api.yaml
@@ -3689,3 +3689,125 @@ objects:
         description: |
           Output only. The resource name of the Endpoint.
   
+
+    
+  - !ruby/object:Api::Resource
+    name: MetadataStoresMetadataSchema
+    base_url: '{{parent}}/metadataSchemas'
+    self_link: '{{name}}'
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation':
+      api: 'https://cloud.google.com/vertex-ai/docs'
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
+         path: 'name'
+         base_url: '{op_id}'
+         wait_ms: 1000
+      result: !ruby/object:Api::OpAsync::Result
+         path: 'response'
+         resource_inside_response: true
+      status: !ruby/object:Api::OpAsync::Status
+        path: 'done'
+        complete: True
+        allowed:
+          - True
+          - False
+      error: !ruby/object:Api::OpAsync::Error
+        path: 'error'
+        message: 'message'
+    description: |-
+        Instance of a general MetadataSchema.
+    properties:
+  
+      - !ruby/object:Api::Type::Enum
+        name: 'schemaType'
+        description: |
+          The type of the MetadataSchema. This is a property that identifies which metadata types will use the MetadataSchema.
+        values:
+          - :METADATA_SCHEMA_TYPE_UNSPECIFIED
+          - :ARTIFACT_TYPE
+          - :EXECUTION_TYPE
+          - :CONTEXT_TYPE
+      - !ruby/object:Api::Type::String
+        name: 'description'
+        description: |
+          Description of the Metadata Schema
+      - !ruby/object:Api::Type::String
+        name: 'schemaVersion'
+        description: |
+          The version of the MetadataSchema. The version's format must match the following regular expression: `^[0-9]+.+.+$`, which would allow to order/compare different versions. Example: 1.0.0, 1.0.1, etc.
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+          Output only. The resource name of the MetadataSchema.
+      - !ruby/object:Api::Type::String
+        name: 'createTime'
+        description: |
+          Output only. Timestamp when this MetadataSchema was created.
+      - !ruby/object:Api::Type::String
+        name: 'schema'
+        description: |
+          Required. The raw YAML string representation of the MetadataSchema. The combination of [MetadataSchema.version] and the schema name given by `title` in [MetadataSchema.schema] must be unique within a MetadataStore. The schema is defined as an OpenAPI 3.0.2 [MetadataSchema Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#schemaObject)
+  
+
+    
+  - !ruby/object:Api::Resource
+    name: MetadataStoresMetadataSchema
+    base_url: '{{parent}}/metadataSchemas'
+    self_link: '{{name}}'
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation':
+      api: 'https://cloud.google.com/vertex-ai/docs'
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
+         path: 'name'
+         base_url: '{op_id}'
+         wait_ms: 1000
+      result: !ruby/object:Api::OpAsync::Result
+         path: 'response'
+         resource_inside_response: true
+      status: !ruby/object:Api::OpAsync::Status
+        path: 'done'
+        complete: True
+        allowed:
+          - True
+          - False
+      error: !ruby/object:Api::OpAsync::Error
+        path: 'error'
+        message: 'message'
+    description: |-
+        Instance of a general MetadataSchema.
+    properties:
+  
+      - !ruby/object:Api::Type::Enum
+        name: 'schemaType'
+        description: |
+          The type of the MetadataSchema. This is a property that identifies which metadata types will use the MetadataSchema.
+        values:
+          - :METADATA_SCHEMA_TYPE_UNSPECIFIED
+          - :ARTIFACT_TYPE
+          - :EXECUTION_TYPE
+          - :CONTEXT_TYPE
+      - !ruby/object:Api::Type::String
+        name: 'description'
+        description: |
+          Description of the Metadata Schema
+      - !ruby/object:Api::Type::String
+        name: 'schemaVersion'
+        description: |
+          The version of the MetadataSchema. The version's format must match the following regular expression: `^[0-9]+.+.+$`, which would allow to order/compare different versions. Example: 1.0.0, 1.0.1, etc.
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+          Output only. The resource name of the MetadataSchema.
+      - !ruby/object:Api::Type::String
+        name: 'createTime'
+        description: |
+          Output only. Timestamp when this MetadataSchema was created.
+      - !ruby/object:Api::Type::String
+        name: 'schema'
+        description: |
+          Required. The raw YAML string representation of the MetadataSchema. The combination of [MetadataSchema.version] and the schema name given by `title` in [MetadataSchema.schema] must be unique within a MetadataStore. The schema is defined as an OpenAPI 3.0.2 [MetadataSchema Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#schemaObject)
+  

--- a/mmv1/templates/inspec/examples/google_vertex_ai_metadata_stores_metadata_schema/google_vertex_ai_metadata_stores_metadata_schema.erb
+++ b/mmv1/templates/inspec/examples/google_vertex_ai_metadata_stores_metadata_schema/google_vertex_ai_metadata_stores_metadata_schema.erb
@@ -1,0 +1,16 @@
+<% gcp_project_id = "#{external_attribute(pwd, 'gcp_project_id', doc_generation)}" -%>
+<% metadata_stores_metadata_schema = grab_attributes(pwd)['metadata_stores_metadata_schema'] -%>
+describe google_vertex_ai_metadata_stores_metadata_schema(name: "projects/#{gcp_project_id}/locations/#{metadata_stores_metadata_schema['region']}/metadataStores/#{metadata_stores_metadata_schema['metadataStore']}/metadataSchemas/#{metadata_stores_metadata_schema['name']}", region: <%= doc_generation ? "' #{metadata_stores_metadata_schema['region']}'":"metadata_stores_metadata_schema['region']" -%>) do
+	it { should exist }
+	its('schema_type') { should cmp <%= doc_generation ? "'#{metadata_stores_metadata_schema['schema_type']}'" : "metadata_stores_metadata_schema['schema_type']" -%> }
+	its('description') { should cmp <%= doc_generation ? "'#{metadata_stores_metadata_schema['description']}'" : "metadata_stores_metadata_schema['description']" -%> }
+	its('schema_version') { should cmp <%= doc_generation ? "'#{metadata_stores_metadata_schema['schema_version']}'" : "metadata_stores_metadata_schema['schema_version']" -%> }
+	its('name') { should cmp <%= doc_generation ? "'#{metadata_stores_metadata_schema['name']}'" : "metadata_stores_metadata_schema['name']" -%> }
+	its('create_time') { should cmp <%= doc_generation ? "'#{metadata_stores_metadata_schema['create_time']}'" : "metadata_stores_metadata_schema['create_time']" -%> }
+	its('schema') { should cmp <%= doc_generation ? "'#{metadata_stores_metadata_schema['schema']}'" : "metadata_stores_metadata_schema['schema']" -%> }
+
+end
+
+describe google_vertex_ai_metadata_stores_metadata_schema(name: "does_not_exit", region: <%= doc_generation ? "' #{metadata_stores_metadata_schema['region']}'":"metadata_stores_metadata_schema['region']" -%>) do
+	it { should_not exist }
+end

--- a/mmv1/templates/inspec/examples/google_vertex_ai_metadata_stores_metadata_schema/google_vertex_ai_metadata_stores_metadata_schema_attributes.erb
+++ b/mmv1/templates/inspec/examples/google_vertex_ai_metadata_stores_metadata_schema/google_vertex_ai_metadata_stores_metadata_schema_attributes.erb
@@ -1,0 +1,3 @@
+gcp_project_id = input(:gcp_project_id, value: '<%= external_attribute(pwd, 'gcp_project_id') -%>', description: 'The GCP project identifier.')
+
+  metadata_stores_metadata_schema = input('metadata_stores_metadata_schema', value: <%= JSON.pretty_generate(grab_attributes(pwd)['metadata_stores_metadata_schema']) -%>, description: 'metadata_stores_metadata_schema description')

--- a/mmv1/templates/inspec/examples/google_vertex_ai_metadata_stores_metadata_schema/google_vertex_ai_metadata_stores_metadata_schemas.erb
+++ b/mmv1/templates/inspec/examples/google_vertex_ai_metadata_stores_metadata_schema/google_vertex_ai_metadata_stores_metadata_schemas.erb
@@ -1,0 +1,5 @@
+<% gcp_project_id = "#{external_attribute(pwd, 'gcp_project_id', doc_generation)}" -%>
+  <% metadata_stores_metadata_schema = grab_attributes(pwd)['metadata_stores_metadata_schema'] -%>
+  describe google_vertex_ai_metadata_stores_metadata_schemas(parent: "projects/#{gcp_project_id}/locations/#{metadata_stores_metadata_schema['region']}/metadataStores/#{metadata_stores_metadata_schema['metadataStore']}", region: <%= doc_generation ? "' #{metadata_stores_metadata_schema['region']}'":"metadata_stores_metadata_schema['region']" -%>) do
+    it { should exist }
+  end

--- a/mmv1/templates/inspec/tests/integration/configuration/mm-attributes.yml
+++ b/mmv1/templates/inspec/tests/integration/configuration/mm-attributes.yml
@@ -600,10 +600,11 @@ endpoint:
   create_time : "value_createtime"
 
 metadata_stores_metadata_schema:
-  name : "value_name"
-  region : "value_region"
-  parent : "value_parent"
-  schema_type : "value_schematype"
+  name : "system-dag-execution-v0-0-1"
+  region : "us-central1"
+  parent : "projects/165434197229/locations/us-central1/metadataStores/default/metadataSchemas/"
+  metadataStore: "default"
+  schema_type : "EXECUTION_TYPE"
   description : "value_description"
   schema_version : "value_schemaversion"
   create_time : "value_createtime"

--- a/mmv1/templates/inspec/tests/integration/configuration/mm-attributes.yml
+++ b/mmv1/templates/inspec/tests/integration/configuration/mm-attributes.yml
@@ -598,3 +598,13 @@ endpoint:
   display_name : "value_displayname"
   etag : "value_etag"
   create_time : "value_createtime"
+
+metadata_stores_metadata_schema:
+  name : "value_name"
+  region : "value_region"
+  parent : "value_parent"
+  schema_type : "value_schematype"
+  description : "value_description"
+  schema_version : "value_schemaversion"
+  create_time : "value_createtime"
+  schema : "value_schema"


### PR DESCRIPTION
Automatically generated by magic modules for service: vertex_ai and resource: MetadataStores__metadataSchema.
This commit includes the following changes:
- Singular Resource ERB File
- Plural Resource ERB File 
- Terraform configuration
- api.yaml configuration for product vertex_ai and resource MetadataStores__metadataSchema