### PR TITLE
CHEF-5583-MAGIC-MODULE-vertex_ai-Tensorboards__experiments__run - Resource Implementation

### DIFF
--- a/mmv1/products/vertexai/api.yaml
+++ b/mmv1/products/vertexai/api.yaml
@@ -6041,3 +6041,68 @@ objects:
                     description: |
                       Optional. The cpu utilization that the Autoscaler should be trying to achieve. This number is on a scale from 0 (no utilization) to 100 (total utilization), and is limited between 10 and 80. When a cluster's CPU utilization exceeds the target that you have set, Bigtable immediately adds nodes to the cluster. When CPU utilization is substantially lower than the target, Bigtable removes nodes. If not set or set to 0, default to 50.
   
+
+    
+  - !ruby/object:Api::Resource
+    name: TensorboardExperimentRun
+    base_url: '{{parent}}/runs'
+    self_link: '{{name}}'
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation':
+      api: 'https://cloud.google.com/vertex-ai/docs'
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
+         path: 'name'
+         base_url: '{op_id}'
+         wait_ms: 1000
+      result: !ruby/object:Api::OpAsync::Result
+         path: 'response'
+         resource_inside_response: true
+      status: !ruby/object:Api::OpAsync::Status
+        path: 'done'
+        complete: True
+        allowed:
+          - True
+          - False
+      error: !ruby/object:Api::OpAsync::Error
+        path: 'error'
+        message: 'message'
+    description: |-
+        TensorboardRun maps to a specific execution of a training job with a given set of hyperparameter values, model definition, dataset, etc
+    properties:
+  
+      - !ruby/object:Api::Type::String
+        name: 'displayName'
+        description: |
+          Required. User provided name of this TensorboardRun. This value must be unique among all TensorboardRuns belonging to the same parent TensorboardExperiment.
+      - !ruby/object:Api::Type::String
+        name: 'updateTime'
+        description: |
+          Output only. Timestamp when this TensorboardRun was last updated.
+      - !ruby/object:Api::Type::String
+        name: 'description'
+        description: |
+          Description of this TensorboardRun.
+      - !ruby/object:Api::Type::String
+        name: 'etag'
+        description: |
+          Used to perform a consistent read-modify-write updates. If not set, a blind "overwrite" update happens.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'labels'
+        description: |
+          The labels with user-defined metadata to organize your TensorboardRuns. This field will be used to filter and visualize Runs in the Tensorboard UI. For example, a Vertex AI training job can set a label aiplatform.googleapis.com/training_job_id=xxxxx to all the runs created within that job. An end user can set a label experiment_id=xxxxx for all the runs produced in a Jupyter notebook. These runs can be grouped by a label value and visualized together in the Tensorboard UI. Label keys and values can be no longer than 64 characters (Unicode codepoints), can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. No more than 64 user labels can be associated with one TensorboardRun (System labels are excluded). See https://goo.gl/xmQnxf for more information and examples of labels. System reserved label keys are prefixed with "aiplatform.googleapis.com/" and are immutable.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'additionalProperties'
+            description: |
+              
+      - !ruby/object:Api::Type::String
+        name: 'createTime'
+        description: |
+          Output only. Timestamp when this TensorboardRun was created.
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+          Output only. Name of the TensorboardRun. Format: `projects/{project}/locations/{location}/tensorboards/{tensorboard}/experiments/{experiment}/runs/{run}`
+  

--- a/mmv1/templates/inspec/examples/google_vertex_ai_tensorboard_experiment_run/google_vertex_ai_tensorboard_experiment_run.erb
+++ b/mmv1/templates/inspec/examples/google_vertex_ai_tensorboard_experiment_run/google_vertex_ai_tensorboard_experiment_run.erb
@@ -1,0 +1,10 @@
+<% gcp_project_id = "#{external_attribute(pwd, 'gcp_project_id', doc_generation)}" -%>
+<% tensorboard_experiment_run = grab_attributes(pwd)['tensorboard_experiment_run'] -%>
+describe google_vertex_ai_tensorboard_experiment_run(name: "projects/#{gcp_project_id}/locations/#{tensorboard_experiment_run['region']}/tensorboards/#{tensorboard_experiment_run['tensorboard']}/experiments/#{tensorboard_experiment_run['experiment']}/runs/#{tensorboard_experiment_run['run']}", region: <%= doc_generation ? "' #{tensorboard_experiment_run['region']}'":"tensorboard_experiment_run['region']" -%>) do
+	it { should exist }
+
+end
+
+describe google_vertex_ai_tensorboard_experiment_run(name: "does_not_exit", region: <%= doc_generation ? "' #{tensorboard_experiment_run['region']}'":"tensorboard_experiment_run['region']" -%>) do
+	it { should_not exist }
+end

--- a/mmv1/templates/inspec/examples/google_vertex_ai_tensorboard_experiment_run/google_vertex_ai_tensorboard_experiment_run_attributes.erb
+++ b/mmv1/templates/inspec/examples/google_vertex_ai_tensorboard_experiment_run/google_vertex_ai_tensorboard_experiment_run_attributes.erb
@@ -1,0 +1,3 @@
+gcp_project_id = input(:gcp_project_id, value: '<%= external_attribute(pwd, 'gcp_project_id') -%>', description: 'The GCP project identifier.')
+
+  tensorboard_experiment_run = input('tensorboard_experiment_run', value: <%= JSON.pretty_generate(grab_attributes(pwd)['tensorboard_experiment_run']) -%>, description: 'tensorboard_experiment_run description')

--- a/mmv1/templates/inspec/examples/google_vertex_ai_tensorboard_experiment_run/google_vertex_ai_tensorboard_experiment_runs.erb
+++ b/mmv1/templates/inspec/examples/google_vertex_ai_tensorboard_experiment_run/google_vertex_ai_tensorboard_experiment_runs.erb
@@ -1,0 +1,5 @@
+<% gcp_project_id = "#{external_attribute(pwd, 'gcp_project_id', doc_generation)}" -%>
+  <% tensorboard_experiment_run = grab_attributes(pwd)['tensorboard_experiment_run'] -%>
+  describe google_vertex_ai_tensorboard_experiment_runs(parent: "projects/#{gcp_project_id}/locations/#{tensorboard_experiment_run['region']}/tensorboards/#{tensorboard_experiment_run['tensorboard']}/experiments/#{tensorboard_experiment_run['experiment']}", region: <%= doc_generation ? "' #{tensorboard_experiment_run['region']}'":"tensorboard_experiment_run['region']" -%>) do
+    it { should exist }
+  end

--- a/mmv1/templates/inspec/tests/integration/configuration/mm-attributes.yml
+++ b/mmv1/templates/inspec/tests/integration/configuration/mm-attributes.yml
@@ -645,6 +645,8 @@ featurestores_entity_type:
   update_time : "value_updatetime"
 
 tensorboard_experiment_run:
-  name : "value_name"
-  region : "value_region"
-  parent : "value_parent"
+  name : "sklearn-2023-09-22-17-16-16-a25b0"
+  tensorboard: "1976367752880848896"
+  experiment: "autologging-experiment-fyc24zb2"
+  region : "us-central1"
+  parent : "projects/165434197229/locations/us-central1/tensorboards/1976367752880848896/experiments/autologging-experiment-fyc24zb2/runs/"

--- a/mmv1/templates/inspec/tests/integration/configuration/mm-attributes.yml
+++ b/mmv1/templates/inspec/tests/integration/configuration/mm-attributes.yml
@@ -643,3 +643,8 @@ featurestores_entity_type:
   create_time : "value_createtime"
   etag : "value_etag"
   update_time : "value_updatetime"
+
+tensorboard_experiment_run:
+  name : "value_name"
+  region : "value_region"
+  parent : "value_parent"


### PR DESCRIPTION
Automatically generated by magic modules for service: vertex_ai and resource: Tensorboards__experiments__run.
This commit includes the following changes:
- Singular Resource ERB File
- Plural Resource ERB File 
- Terraform configuration
- api.yaml configuration for product vertex_ai and resource Tensorboards__experiments__run