### PR TITLE
CHEF-ORG-MAGIC-MODULE-orgpolicy-Folders__policy - Resource Implementation

### DIFF
--- a/mmv1/products/orgpolicy/api.yaml
+++ b/mmv1/products/orgpolicy/api.yaml
@@ -1,0 +1,568 @@
+
+--- !ruby/object:Api::Product
+name: orgpolicy
+display_name: orgpolicy
+versions:
+  - !ruby/object:Api::Product::Version
+    name: ga
+    base_url: https://orgpolicy.googleapis.com//v1/
+scopes:
+  - https://orgpolicy.googleapis.com//auth/cloud-platform
+apis_required:
+  - !ruby/object:Api::Product::ApiReference
+    name: https://orgpolicy.googleapis.com/
+    url: https://console.cloud.google.com/apis/library/orgpolicy.googleapis.com/
+objects:
+    
+  - !ruby/object:Api::Resource
+    name: FolderPolicy
+    base_url: 'v2/{{parent}}/policies'
+    self_link: 'v2/{{name}}'
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation':
+      api: 'https://cloud.google.com/orgpolicy/docs'
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
+         path: 'name'
+         base_url: '{op_id}'
+         wait_ms: 1000
+      result: !ruby/object:Api::OpAsync::Result
+         path: 'response'
+         resource_inside_response: true
+      status: !ruby/object:Api::OpAsync::Status
+        path: 'done'
+        complete: True
+        allowed:
+          - True
+          - False
+      error: !ruby/object:Api::OpAsync::Error
+        path: 'error'
+        message: 'message'
+    description: |-
+        Defines an organization policy which is used to specify constraints for configurations of Google Cloud resources.
+    properties:
+  
+      - !ruby/object:Api::Type::NestedObject
+        name: 'dryRunSpec'
+        description: |
+          Defines a Google Cloud policy specification which is used to specify constraints for configurations of Google Cloud resources.
+        properties:
+            - !ruby/object:Api::Type::String
+              name: 'updateTime'
+              description: |
+                Output only. The time stamp this was previously updated. This represents the last time a call to `CreatePolicy` or `UpdatePolicy` was made for that policy.
+            - !ruby/object:Api::Type::Array
+              name: 'rules'
+              description: |
+                In policies for boolean constraints, the following requirements apply: - There must be one and only one policy rule where condition is unset. - Boolean policy rules with conditions must set `enforced` to the opposite of the policy rule without a condition. - During policy evaluation, policy rules with conditions that are true for a target resource take precedence.
+              item_type: !ruby/object:Api::Type::NestedObject
+                properties:
+                  - !ruby/object:Api::Type::NestedObject
+                    name: 'condition'
+                    description: |
+                      Represents a textual expression in the Common Expression Language (CEL) syntax. CEL is a C-like expression language. The syntax and semantics of CEL are documented at https://github.com/google/cel-spec. Example (Comparison): title: "Summary size limit" description: "Determines if a summary is less than 100 chars" expression: "document.summary.size() < 100" Example (Equality): title: "Requestor is owner" description: "Determines if requestor is the document owner" expression: "document.owner == request.auth.claims.email" Example (Logic): title: "Public documents" description: "Determine whether the document should be publicly visible" expression: "document.type != 'private' && document.type != 'internal'" Example (Data Manipulation): title: "Notification string" description: "Create a notification string with a timestamp." expression: "'New message received at ' + string(document.create_time)" The exact variables and functions that may be referenced within an expression are determined by the service that evaluates it. See the service documentation for additional information.
+                    properties:
+                        - !ruby/object:Api::Type::String
+                          name: 'title'
+                          description: |
+                            Optional. Title for the expression, i.e. a short string describing its purpose. This can be used e.g. in UIs which allow to enter the expression.
+                        - !ruby/object:Api::Type::String
+                          name: 'location'
+                          description: |
+                            Optional. String indicating the location of the expression for error reporting, e.g. a file name and a position in the file.
+                        - !ruby/object:Api::Type::String
+                          name: 'expression'
+                          description: |
+                            Textual representation of an expression in Common Expression Language syntax.
+                        - !ruby/object:Api::Type::String
+                          name: 'description'
+                          description: |
+                            Optional. Description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.
+                  - !ruby/object:Api::Type::Boolean
+                    name: 'denyAll'
+                    description: |
+                      Setting this to true means that all values are denied. This field can be set only in policies for list constraints.
+                  - !ruby/object:Api::Type::Boolean
+                    name: 'allowAll'
+                    description: |
+                      Setting this to true means that all values are allowed. This field can be set only in policies for list constraints.
+                  - !ruby/object:Api::Type::Boolean
+                    name: 'enforce'
+                    description: |
+                      If `true`, then the policy is enforced. If `false`, then any configuration is acceptable. This field can be set only in policies for boolean constraints.
+                  - !ruby/object:Api::Type::NestedObject
+                    name: 'values'
+                    description: |
+                      A message that holds specific allowed and denied values. This message can define specific values and subtrees of the Resource Manager resource hierarchy (`Organizations`, `Folders`, `Projects`) that are allowed or denied. This is achieved by using the `under:` and optional `is:` prefixes. The `under:` prefix is used to denote resource subtree values. The `is:` prefix is used to denote specific values, and is required only if the value contains a ":". Values prefixed with "is:" are treated the same as values with no prefix. Ancestry subtrees must be in one of the following formats: - `projects/` (for example, `projects/tokyo-rain-123`) - `folders/` (for example, `folders/1234`) - `organizations/` (for example, `organizations/1234`) The `supports_under` field of the associated `Constraint` defines whether ancestry prefixes can be used.
+                    properties:
+                        - !ruby/object:Api::Type::Array
+                          name: 'deniedValues'
+                          description: |
+                            List of values denied at this resource.
+                          item_type: Api::Type::String
+                        - !ruby/object:Api::Type::Array
+                          name: 'allowedValues'
+                          description: |
+                            List of values allowed at this resource.
+                          item_type: Api::Type::String
+            - !ruby/object:Api::Type::String
+              name: 'etag'
+              description: |
+                An opaque tag indicating the current version of the policySpec, used for concurrency control. This field is ignored if used in a `CreatePolicy` request. When the policy is returned from either a `GetPolicy` or a `ListPolicies` request, this `etag` indicates the version of the current policySpec to use when executing a read-modify-write loop. When the policy is returned from a `GetEffectivePolicy` request, the `etag` will be unset.
+            - !ruby/object:Api::Type::Boolean
+              name: 'reset'
+              description: |
+                Ignores policies set above this resource and restores the `constraint_default` enforcement behavior of the specific constraint at this resource. This field can be set in policies for either list or boolean constraints. If set, `rules` must be empty and `inherit_from_parent` must be set to false.
+            - !ruby/object:Api::Type::Boolean
+              name: 'inheritFromParent'
+              description: |
+                Determines the inheritance behavior for this policy. If `inherit_from_parent` is true, policy rules set higher up in the hierarchy (up to the closest root) are inherited and present in the effective policy. If it is false, then no rules are inherited, and this policy becomes the new root for evaluation. This field can be set only for policies which configure list constraints.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'spec'
+        description: |
+          Defines a Google Cloud policy specification which is used to specify constraints for configurations of Google Cloud resources.
+        properties:
+            - !ruby/object:Api::Type::String
+              name: 'updateTime'
+              description: |
+                Output only. The time stamp this was previously updated. This represents the last time a call to `CreatePolicy` or `UpdatePolicy` was made for that policy.
+            - !ruby/object:Api::Type::Array
+              name: 'rules'
+              description: |
+                In policies for boolean constraints, the following requirements apply: - There must be one and only one policy rule where condition is unset. - Boolean policy rules with conditions must set `enforced` to the opposite of the policy rule without a condition. - During policy evaluation, policy rules with conditions that are true for a target resource take precedence.
+              item_type: !ruby/object:Api::Type::NestedObject
+                properties:
+                  - !ruby/object:Api::Type::NestedObject
+                    name: 'condition'
+                    description: |
+                      Represents a textual expression in the Common Expression Language (CEL) syntax. CEL is a C-like expression language. The syntax and semantics of CEL are documented at https://github.com/google/cel-spec. Example (Comparison): title: "Summary size limit" description: "Determines if a summary is less than 100 chars" expression: "document.summary.size() < 100" Example (Equality): title: "Requestor is owner" description: "Determines if requestor is the document owner" expression: "document.owner == request.auth.claims.email" Example (Logic): title: "Public documents" description: "Determine whether the document should be publicly visible" expression: "document.type != 'private' && document.type != 'internal'" Example (Data Manipulation): title: "Notification string" description: "Create a notification string with a timestamp." expression: "'New message received at ' + string(document.create_time)" The exact variables and functions that may be referenced within an expression are determined by the service that evaluates it. See the service documentation for additional information.
+                    properties:
+                        - !ruby/object:Api::Type::String
+                          name: 'title'
+                          description: |
+                            Optional. Title for the expression, i.e. a short string describing its purpose. This can be used e.g. in UIs which allow to enter the expression.
+                        - !ruby/object:Api::Type::String
+                          name: 'location'
+                          description: |
+                            Optional. String indicating the location of the expression for error reporting, e.g. a file name and a position in the file.
+                        - !ruby/object:Api::Type::String
+                          name: 'expression'
+                          description: |
+                            Textual representation of an expression in Common Expression Language syntax.
+                        - !ruby/object:Api::Type::String
+                          name: 'description'
+                          description: |
+                            Optional. Description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.
+                  - !ruby/object:Api::Type::Boolean
+                    name: 'denyAll'
+                    description: |
+                      Setting this to true means that all values are denied. This field can be set only in policies for list constraints.
+                  - !ruby/object:Api::Type::Boolean
+                    name: 'allowAll'
+                    description: |
+                      Setting this to true means that all values are allowed. This field can be set only in policies for list constraints.
+                  - !ruby/object:Api::Type::Boolean
+                    name: 'enforce'
+                    description: |
+                      If `true`, then the policy is enforced. If `false`, then any configuration is acceptable. This field can be set only in policies for boolean constraints.
+                  - !ruby/object:Api::Type::NestedObject
+                    name: 'values'
+                    description: |
+                      A message that holds specific allowed and denied values. This message can define specific values and subtrees of the Resource Manager resource hierarchy (`Organizations`, `Folders`, `Projects`) that are allowed or denied. This is achieved by using the `under:` and optional `is:` prefixes. The `under:` prefix is used to denote resource subtree values. The `is:` prefix is used to denote specific values, and is required only if the value contains a ":". Values prefixed with "is:" are treated the same as values with no prefix. Ancestry subtrees must be in one of the following formats: - `projects/` (for example, `projects/tokyo-rain-123`) - `folders/` (for example, `folders/1234`) - `organizations/` (for example, `organizations/1234`) The `supports_under` field of the associated `Constraint` defines whether ancestry prefixes can be used.
+                    properties:
+                        - !ruby/object:Api::Type::Array
+                          name: 'deniedValues'
+                          description: |
+                            List of values denied at this resource.
+                          item_type: Api::Type::String
+                        - !ruby/object:Api::Type::Array
+                          name: 'allowedValues'
+                          description: |
+                            List of values allowed at this resource.
+                          item_type: Api::Type::String
+            - !ruby/object:Api::Type::String
+              name: 'etag'
+              description: |
+                An opaque tag indicating the current version of the policySpec, used for concurrency control. This field is ignored if used in a `CreatePolicy` request. When the policy is returned from either a `GetPolicy` or a `ListPolicies` request, this `etag` indicates the version of the current policySpec to use when executing a read-modify-write loop. When the policy is returned from a `GetEffectivePolicy` request, the `etag` will be unset.
+            - !ruby/object:Api::Type::Boolean
+              name: 'reset'
+              description: |
+                Ignores policies set above this resource and restores the `constraint_default` enforcement behavior of the specific constraint at this resource. This field can be set in policies for either list or boolean constraints. If set, `rules` must be empty and `inherit_from_parent` must be set to false.
+            - !ruby/object:Api::Type::Boolean
+              name: 'inheritFromParent'
+              description: |
+                Determines the inheritance behavior for this policy. If `inherit_from_parent` is true, policy rules set higher up in the hierarchy (up to the closest root) are inherited and present in the effective policy. If it is false, then no rules are inherited, and this policy becomes the new root for evaluation. This field can be set only for policies which configure list constraints.
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+          Immutable. The resource name of the policy. Must be one of the following forms, where `constraint_name` is the name of the constraint which this policy configures: * `projects/{project_number}/policies/{constraint_name}` * `folders/{folder_id}/policies/{constraint_name}` * `organizations/{organization_id}/policies/{constraint_name}` For example, `projects/123/policies/compute.disableSerialPortAccess`. Note: `projects/{project_id}/policies/{constraint_name}` is also an acceptable name for API requests, but responses will return the name using the equivalent project number.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'alternate'
+        description: |
+          Similar to PolicySpec but with an extra 'launch' field for launch reference. The PolicySpec here is specific for dry-run/darklaunch.
+        properties:
+            - !ruby/object:Api::Type::String
+              name: 'launch'
+              description: |
+                Reference to the launch that will be used while audit logging and to control the launch. Should be set only in the alternate policy.
+            - !ruby/object:Api::Type::NestedObject
+              name: 'spec'
+              description: |
+                Defines a Google Cloud policy specification which is used to specify constraints for configurations of Google Cloud resources.
+              properties:
+                  - !ruby/object:Api::Type::String
+                    name: 'updateTime'
+                    description: |
+                      Output only. The time stamp this was previously updated. This represents the last time a call to `CreatePolicy` or `UpdatePolicy` was made for that policy.
+                  - !ruby/object:Api::Type::Array
+                    name: 'rules'
+                    description: |
+                      In policies for boolean constraints, the following requirements apply: - There must be one and only one policy rule where condition is unset. - Boolean policy rules with conditions must set `enforced` to the opposite of the policy rule without a condition. - During policy evaluation, policy rules with conditions that are true for a target resource take precedence.
+                    item_type: !ruby/object:Api::Type::NestedObject
+                      properties:
+                        - !ruby/object:Api::Type::NestedObject
+                          name: 'condition'
+                          description: |
+                            Represents a textual expression in the Common Expression Language (CEL) syntax. CEL is a C-like expression language. The syntax and semantics of CEL are documented at https://github.com/google/cel-spec. Example (Comparison): title: "Summary size limit" description: "Determines if a summary is less than 100 chars" expression: "document.summary.size() < 100" Example (Equality): title: "Requestor is owner" description: "Determines if requestor is the document owner" expression: "document.owner == request.auth.claims.email" Example (Logic): title: "Public documents" description: "Determine whether the document should be publicly visible" expression: "document.type != 'private' && document.type != 'internal'" Example (Data Manipulation): title: "Notification string" description: "Create a notification string with a timestamp." expression: "'New message received at ' + string(document.create_time)" The exact variables and functions that may be referenced within an expression are determined by the service that evaluates it. See the service documentation for additional information.
+                          properties:
+                              - !ruby/object:Api::Type::String
+                                name: 'title'
+                                description: |
+                                  Optional. Title for the expression, i.e. a short string describing its purpose. This can be used e.g. in UIs which allow to enter the expression.
+                              - !ruby/object:Api::Type::String
+                                name: 'location'
+                                description: |
+                                  Optional. String indicating the location of the expression for error reporting, e.g. a file name and a position in the file.
+                              - !ruby/object:Api::Type::String
+                                name: 'expression'
+                                description: |
+                                  Textual representation of an expression in Common Expression Language syntax.
+                              - !ruby/object:Api::Type::String
+                                name: 'description'
+                                description: |
+                                  Optional. Description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.
+                        - !ruby/object:Api::Type::Boolean
+                          name: 'denyAll'
+                          description: |
+                            Setting this to true means that all values are denied. This field can be set only in policies for list constraints.
+                        - !ruby/object:Api::Type::Boolean
+                          name: 'allowAll'
+                          description: |
+                            Setting this to true means that all values are allowed. This field can be set only in policies for list constraints.
+                        - !ruby/object:Api::Type::Boolean
+                          name: 'enforce'
+                          description: |
+                            If `true`, then the policy is enforced. If `false`, then any configuration is acceptable. This field can be set only in policies for boolean constraints.
+                        - !ruby/object:Api::Type::NestedObject
+                          name: 'values'
+                          description: |
+                            A message that holds specific allowed and denied values. This message can define specific values and subtrees of the Resource Manager resource hierarchy (`Organizations`, `Folders`, `Projects`) that are allowed or denied. This is achieved by using the `under:` and optional `is:` prefixes. The `under:` prefix is used to denote resource subtree values. The `is:` prefix is used to denote specific values, and is required only if the value contains a ":". Values prefixed with "is:" are treated the same as values with no prefix. Ancestry subtrees must be in one of the following formats: - `projects/` (for example, `projects/tokyo-rain-123`) - `folders/` (for example, `folders/1234`) - `organizations/` (for example, `organizations/1234`) The `supports_under` field of the associated `Constraint` defines whether ancestry prefixes can be used.
+                          properties:
+                              - !ruby/object:Api::Type::Array
+                                name: 'deniedValues'
+                                description: |
+                                  List of values denied at this resource.
+                                item_type: Api::Type::String
+                              - !ruby/object:Api::Type::Array
+                                name: 'allowedValues'
+                                description: |
+                                  List of values allowed at this resource.
+                                item_type: Api::Type::String
+                  - !ruby/object:Api::Type::String
+                    name: 'etag'
+                    description: |
+                      An opaque tag indicating the current version of the policySpec, used for concurrency control. This field is ignored if used in a `CreatePolicy` request. When the policy is returned from either a `GetPolicy` or a `ListPolicies` request, this `etag` indicates the version of the current policySpec to use when executing a read-modify-write loop. When the policy is returned from a `GetEffectivePolicy` request, the `etag` will be unset.
+                  - !ruby/object:Api::Type::Boolean
+                    name: 'reset'
+                    description: |
+                      Ignores policies set above this resource and restores the `constraint_default` enforcement behavior of the specific constraint at this resource. This field can be set in policies for either list or boolean constraints. If set, `rules` must be empty and `inherit_from_parent` must be set to false.
+                  - !ruby/object:Api::Type::Boolean
+                    name: 'inheritFromParent'
+                    description: |
+                      Determines the inheritance behavior for this policy. If `inherit_from_parent` is true, policy rules set higher up in the hierarchy (up to the closest root) are inherited and present in the effective policy. If it is false, then no rules are inherited, and this policy becomes the new root for evaluation. This field can be set only for policies which configure list constraints.
+  
+
+--- !ruby/object:Api::Product
+name: orgpolicy
+display_name: orgpolicy
+versions:
+  - !ruby/object:Api::Product::Version
+    name: ga
+    base_url: https://orgpolicy.googleapis.com//v1/
+scopes:
+  - https://orgpolicy.googleapis.com//auth/cloud-platform
+apis_required:
+  - !ruby/object:Api::Product::ApiReference
+    name: https://orgpolicy.googleapis.com/
+    url: https://console.cloud.google.com/apis/library/orgpolicy.googleapis.com/
+objects:
+    
+  - !ruby/object:Api::Resource
+    name: FolderPolicy
+    base_url: 'v2/{{parent}}/policies'
+    self_link: 'v2/{{name}}'
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation':
+      api: 'https://cloud.google.com/orgpolicy/docs'
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
+         path: 'name'
+         base_url: '{op_id}'
+         wait_ms: 1000
+      result: !ruby/object:Api::OpAsync::Result
+         path: 'response'
+         resource_inside_response: true
+      status: !ruby/object:Api::OpAsync::Status
+        path: 'done'
+        complete: True
+        allowed:
+          - True
+          - False
+      error: !ruby/object:Api::OpAsync::Error
+        path: 'error'
+        message: 'message'
+    description: |-
+        Defines an organization policy which is used to specify constraints for configurations of Google Cloud resources.
+    properties:
+  
+      - !ruby/object:Api::Type::NestedObject
+        name: 'dryRunSpec'
+        description: |
+          Defines a Google Cloud policy specification which is used to specify constraints for configurations of Google Cloud resources.
+        properties:
+            - !ruby/object:Api::Type::String
+              name: 'updateTime'
+              description: |
+                Output only. The time stamp this was previously updated. This represents the last time a call to `CreatePolicy` or `UpdatePolicy` was made for that policy.
+            - !ruby/object:Api::Type::Array
+              name: 'rules'
+              description: |
+                In policies for boolean constraints, the following requirements apply: - There must be one and only one policy rule where condition is unset. - Boolean policy rules with conditions must set `enforced` to the opposite of the policy rule without a condition. - During policy evaluation, policy rules with conditions that are true for a target resource take precedence.
+              item_type: !ruby/object:Api::Type::NestedObject
+                properties:
+                  - !ruby/object:Api::Type::NestedObject
+                    name: 'condition'
+                    description: |
+                      Represents a textual expression in the Common Expression Language (CEL) syntax. CEL is a C-like expression language. The syntax and semantics of CEL are documented at https://github.com/google/cel-spec. Example (Comparison): title: "Summary size limit" description: "Determines if a summary is less than 100 chars" expression: "document.summary.size() < 100" Example (Equality): title: "Requestor is owner" description: "Determines if requestor is the document owner" expression: "document.owner == request.auth.claims.email" Example (Logic): title: "Public documents" description: "Determine whether the document should be publicly visible" expression: "document.type != 'private' && document.type != 'internal'" Example (Data Manipulation): title: "Notification string" description: "Create a notification string with a timestamp." expression: "'New message received at ' + string(document.create_time)" The exact variables and functions that may be referenced within an expression are determined by the service that evaluates it. See the service documentation for additional information.
+                    properties:
+                        - !ruby/object:Api::Type::String
+                          name: 'title'
+                          description: |
+                            Optional. Title for the expression, i.e. a short string describing its purpose. This can be used e.g. in UIs which allow to enter the expression.
+                        - !ruby/object:Api::Type::String
+                          name: 'location'
+                          description: |
+                            Optional. String indicating the location of the expression for error reporting, e.g. a file name and a position in the file.
+                        - !ruby/object:Api::Type::String
+                          name: 'expression'
+                          description: |
+                            Textual representation of an expression in Common Expression Language syntax.
+                        - !ruby/object:Api::Type::String
+                          name: 'description'
+                          description: |
+                            Optional. Description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.
+                  - !ruby/object:Api::Type::Boolean
+                    name: 'denyAll'
+                    description: |
+                      Setting this to true means that all values are denied. This field can be set only in policies for list constraints.
+                  - !ruby/object:Api::Type::Boolean
+                    name: 'allowAll'
+                    description: |
+                      Setting this to true means that all values are allowed. This field can be set only in policies for list constraints.
+                  - !ruby/object:Api::Type::Boolean
+                    name: 'enforce'
+                    description: |
+                      If `true`, then the policy is enforced. If `false`, then any configuration is acceptable. This field can be set only in policies for boolean constraints.
+                  - !ruby/object:Api::Type::NestedObject
+                    name: 'values'
+                    description: |
+                      A message that holds specific allowed and denied values. This message can define specific values and subtrees of the Resource Manager resource hierarchy (`Organizations`, `Folders`, `Projects`) that are allowed or denied. This is achieved by using the `under:` and optional `is:` prefixes. The `under:` prefix is used to denote resource subtree values. The `is:` prefix is used to denote specific values, and is required only if the value contains a ":". Values prefixed with "is:" are treated the same as values with no prefix. Ancestry subtrees must be in one of the following formats: - `projects/` (for example, `projects/tokyo-rain-123`) - `folders/` (for example, `folders/1234`) - `organizations/` (for example, `organizations/1234`) The `supports_under` field of the associated `Constraint` defines whether ancestry prefixes can be used.
+                    properties:
+                        - !ruby/object:Api::Type::Array
+                          name: 'deniedValues'
+                          description: |
+                            List of values denied at this resource.
+                          item_type: Api::Type::String
+                        - !ruby/object:Api::Type::Array
+                          name: 'allowedValues'
+                          description: |
+                            List of values allowed at this resource.
+                          item_type: Api::Type::String
+            - !ruby/object:Api::Type::String
+              name: 'etag'
+              description: |
+                An opaque tag indicating the current version of the policySpec, used for concurrency control. This field is ignored if used in a `CreatePolicy` request. When the policy is returned from either a `GetPolicy` or a `ListPolicies` request, this `etag` indicates the version of the current policySpec to use when executing a read-modify-write loop. When the policy is returned from a `GetEffectivePolicy` request, the `etag` will be unset.
+            - !ruby/object:Api::Type::Boolean
+              name: 'reset'
+              description: |
+                Ignores policies set above this resource and restores the `constraint_default` enforcement behavior of the specific constraint at this resource. This field can be set in policies for either list or boolean constraints. If set, `rules` must be empty and `inherit_from_parent` must be set to false.
+            - !ruby/object:Api::Type::Boolean
+              name: 'inheritFromParent'
+              description: |
+                Determines the inheritance behavior for this policy. If `inherit_from_parent` is true, policy rules set higher up in the hierarchy (up to the closest root) are inherited and present in the effective policy. If it is false, then no rules are inherited, and this policy becomes the new root for evaluation. This field can be set only for policies which configure list constraints.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'spec'
+        description: |
+          Defines a Google Cloud policy specification which is used to specify constraints for configurations of Google Cloud resources.
+        properties:
+            - !ruby/object:Api::Type::String
+              name: 'updateTime'
+              description: |
+                Output only. The time stamp this was previously updated. This represents the last time a call to `CreatePolicy` or `UpdatePolicy` was made for that policy.
+            - !ruby/object:Api::Type::Array
+              name: 'rules'
+              description: |
+                In policies for boolean constraints, the following requirements apply: - There must be one and only one policy rule where condition is unset. - Boolean policy rules with conditions must set `enforced` to the opposite of the policy rule without a condition. - During policy evaluation, policy rules with conditions that are true for a target resource take precedence.
+              item_type: !ruby/object:Api::Type::NestedObject
+                properties:
+                  - !ruby/object:Api::Type::NestedObject
+                    name: 'condition'
+                    description: |
+                      Represents a textual expression in the Common Expression Language (CEL) syntax. CEL is a C-like expression language. The syntax and semantics of CEL are documented at https://github.com/google/cel-spec. Example (Comparison): title: "Summary size limit" description: "Determines if a summary is less than 100 chars" expression: "document.summary.size() < 100" Example (Equality): title: "Requestor is owner" description: "Determines if requestor is the document owner" expression: "document.owner == request.auth.claims.email" Example (Logic): title: "Public documents" description: "Determine whether the document should be publicly visible" expression: "document.type != 'private' && document.type != 'internal'" Example (Data Manipulation): title: "Notification string" description: "Create a notification string with a timestamp." expression: "'New message received at ' + string(document.create_time)" The exact variables and functions that may be referenced within an expression are determined by the service that evaluates it. See the service documentation for additional information.
+                    properties:
+                        - !ruby/object:Api::Type::String
+                          name: 'title'
+                          description: |
+                            Optional. Title for the expression, i.e. a short string describing its purpose. This can be used e.g. in UIs which allow to enter the expression.
+                        - !ruby/object:Api::Type::String
+                          name: 'location'
+                          description: |
+                            Optional. String indicating the location of the expression for error reporting, e.g. a file name and a position in the file.
+                        - !ruby/object:Api::Type::String
+                          name: 'expression'
+                          description: |
+                            Textual representation of an expression in Common Expression Language syntax.
+                        - !ruby/object:Api::Type::String
+                          name: 'description'
+                          description: |
+                            Optional. Description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.
+                  - !ruby/object:Api::Type::Boolean
+                    name: 'denyAll'
+                    description: |
+                      Setting this to true means that all values are denied. This field can be set only in policies for list constraints.
+                  - !ruby/object:Api::Type::Boolean
+                    name: 'allowAll'
+                    description: |
+                      Setting this to true means that all values are allowed. This field can be set only in policies for list constraints.
+                  - !ruby/object:Api::Type::Boolean
+                    name: 'enforce'
+                    description: |
+                      If `true`, then the policy is enforced. If `false`, then any configuration is acceptable. This field can be set only in policies for boolean constraints.
+                  - !ruby/object:Api::Type::NestedObject
+                    name: 'values'
+                    description: |
+                      A message that holds specific allowed and denied values. This message can define specific values and subtrees of the Resource Manager resource hierarchy (`Organizations`, `Folders`, `Projects`) that are allowed or denied. This is achieved by using the `under:` and optional `is:` prefixes. The `under:` prefix is used to denote resource subtree values. The `is:` prefix is used to denote specific values, and is required only if the value contains a ":". Values prefixed with "is:" are treated the same as values with no prefix. Ancestry subtrees must be in one of the following formats: - `projects/` (for example, `projects/tokyo-rain-123`) - `folders/` (for example, `folders/1234`) - `organizations/` (for example, `organizations/1234`) The `supports_under` field of the associated `Constraint` defines whether ancestry prefixes can be used.
+                    properties:
+                        - !ruby/object:Api::Type::Array
+                          name: 'deniedValues'
+                          description: |
+                            List of values denied at this resource.
+                          item_type: Api::Type::String
+                        - !ruby/object:Api::Type::Array
+                          name: 'allowedValues'
+                          description: |
+                            List of values allowed at this resource.
+                          item_type: Api::Type::String
+            - !ruby/object:Api::Type::String
+              name: 'etag'
+              description: |
+                An opaque tag indicating the current version of the policySpec, used for concurrency control. This field is ignored if used in a `CreatePolicy` request. When the policy is returned from either a `GetPolicy` or a `ListPolicies` request, this `etag` indicates the version of the current policySpec to use when executing a read-modify-write loop. When the policy is returned from a `GetEffectivePolicy` request, the `etag` will be unset.
+            - !ruby/object:Api::Type::Boolean
+              name: 'reset'
+              description: |
+                Ignores policies set above this resource and restores the `constraint_default` enforcement behavior of the specific constraint at this resource. This field can be set in policies for either list or boolean constraints. If set, `rules` must be empty and `inherit_from_parent` must be set to false.
+            - !ruby/object:Api::Type::Boolean
+              name: 'inheritFromParent'
+              description: |
+                Determines the inheritance behavior for this policy. If `inherit_from_parent` is true, policy rules set higher up in the hierarchy (up to the closest root) are inherited and present in the effective policy. If it is false, then no rules are inherited, and this policy becomes the new root for evaluation. This field can be set only for policies which configure list constraints.
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+          Immutable. The resource name of the policy. Must be one of the following forms, where `constraint_name` is the name of the constraint which this policy configures: * `projects/{project_number}/policies/{constraint_name}` * `folders/{folder_id}/policies/{constraint_name}` * `organizations/{organization_id}/policies/{constraint_name}` For example, `projects/123/policies/compute.disableSerialPortAccess`. Note: `projects/{project_id}/policies/{constraint_name}` is also an acceptable name for API requests, but responses will return the name using the equivalent project number.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'alternate'
+        description: |
+          Similar to PolicySpec but with an extra 'launch' field for launch reference. The PolicySpec here is specific for dry-run/darklaunch.
+        properties:
+            - !ruby/object:Api::Type::String
+              name: 'launch'
+              description: |
+                Reference to the launch that will be used while audit logging and to control the launch. Should be set only in the alternate policy.
+            - !ruby/object:Api::Type::NestedObject
+              name: 'spec'
+              description: |
+                Defines a Google Cloud policy specification which is used to specify constraints for configurations of Google Cloud resources.
+              properties:
+                  - !ruby/object:Api::Type::String
+                    name: 'updateTime'
+                    description: |
+                      Output only. The time stamp this was previously updated. This represents the last time a call to `CreatePolicy` or `UpdatePolicy` was made for that policy.
+                  - !ruby/object:Api::Type::Array
+                    name: 'rules'
+                    description: |
+                      In policies for boolean constraints, the following requirements apply: - There must be one and only one policy rule where condition is unset. - Boolean policy rules with conditions must set `enforced` to the opposite of the policy rule without a condition. - During policy evaluation, policy rules with conditions that are true for a target resource take precedence.
+                    item_type: !ruby/object:Api::Type::NestedObject
+                      properties:
+                        - !ruby/object:Api::Type::NestedObject
+                          name: 'condition'
+                          description: |
+                            Represents a textual expression in the Common Expression Language (CEL) syntax. CEL is a C-like expression language. The syntax and semantics of CEL are documented at https://github.com/google/cel-spec. Example (Comparison): title: "Summary size limit" description: "Determines if a summary is less than 100 chars" expression: "document.summary.size() < 100" Example (Equality): title: "Requestor is owner" description: "Determines if requestor is the document owner" expression: "document.owner == request.auth.claims.email" Example (Logic): title: "Public documents" description: "Determine whether the document should be publicly visible" expression: "document.type != 'private' && document.type != 'internal'" Example (Data Manipulation): title: "Notification string" description: "Create a notification string with a timestamp." expression: "'New message received at ' + string(document.create_time)" The exact variables and functions that may be referenced within an expression are determined by the service that evaluates it. See the service documentation for additional information.
+                          properties:
+                              - !ruby/object:Api::Type::String
+                                name: 'title'
+                                description: |
+                                  Optional. Title for the expression, i.e. a short string describing its purpose. This can be used e.g. in UIs which allow to enter the expression.
+                              - !ruby/object:Api::Type::String
+                                name: 'location'
+                                description: |
+                                  Optional. String indicating the location of the expression for error reporting, e.g. a file name and a position in the file.
+                              - !ruby/object:Api::Type::String
+                                name: 'expression'
+                                description: |
+                                  Textual representation of an expression in Common Expression Language syntax.
+                              - !ruby/object:Api::Type::String
+                                name: 'description'
+                                description: |
+                                  Optional. Description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.
+                        - !ruby/object:Api::Type::Boolean
+                          name: 'denyAll'
+                          description: |
+                            Setting this to true means that all values are denied. This field can be set only in policies for list constraints.
+                        - !ruby/object:Api::Type::Boolean
+                          name: 'allowAll'
+                          description: |
+                            Setting this to true means that all values are allowed. This field can be set only in policies for list constraints.
+                        - !ruby/object:Api::Type::Boolean
+                          name: 'enforce'
+                          description: |
+                            If `true`, then the policy is enforced. If `false`, then any configuration is acceptable. This field can be set only in policies for boolean constraints.
+                        - !ruby/object:Api::Type::NestedObject
+                          name: 'values'
+                          description: |
+                            A message that holds specific allowed and denied values. This message can define specific values and subtrees of the Resource Manager resource hierarchy (`Organizations`, `Folders`, `Projects`) that are allowed or denied. This is achieved by using the `under:` and optional `is:` prefixes. The `under:` prefix is used to denote resource subtree values. The `is:` prefix is used to denote specific values, and is required only if the value contains a ":". Values prefixed with "is:" are treated the same as values with no prefix. Ancestry subtrees must be in one of the following formats: - `projects/` (for example, `projects/tokyo-rain-123`) - `folders/` (for example, `folders/1234`) - `organizations/` (for example, `organizations/1234`) The `supports_under` field of the associated `Constraint` defines whether ancestry prefixes can be used.
+                          properties:
+                              - !ruby/object:Api::Type::Array
+                                name: 'deniedValues'
+                                description: |
+                                  List of values denied at this resource.
+                                item_type: Api::Type::String
+                              - !ruby/object:Api::Type::Array
+                                name: 'allowedValues'
+                                description: |
+                                  List of values allowed at this resource.
+                                item_type: Api::Type::String
+                  - !ruby/object:Api::Type::String
+                    name: 'etag'
+                    description: |
+                      An opaque tag indicating the current version of the policySpec, used for concurrency control. This field is ignored if used in a `CreatePolicy` request. When the policy is returned from either a `GetPolicy` or a `ListPolicies` request, this `etag` indicates the version of the current policySpec to use when executing a read-modify-write loop. When the policy is returned from a `GetEffectivePolicy` request, the `etag` will be unset.
+                  - !ruby/object:Api::Type::Boolean
+                    name: 'reset'
+                    description: |
+                      Ignores policies set above this resource and restores the `constraint_default` enforcement behavior of the specific constraint at this resource. This field can be set in policies for either list or boolean constraints. If set, `rules` must be empty and `inherit_from_parent` must be set to false.
+                  - !ruby/object:Api::Type::Boolean
+                    name: 'inheritFromParent'
+                    description: |
+                      Determines the inheritance behavior for this policy. If `inherit_from_parent` is true, policy rules set higher up in the hierarchy (up to the closest root) are inherited and present in the effective policy. If it is false, then no rules are inherited, and this policy becomes the new root for evaluation. This field can be set only for policies which configure list constraints.
+  

--- a/mmv1/products/orgpolicy/inspec.yaml
+++ b/mmv1/products/orgpolicy/inspec.yaml
@@ -1,0 +1,15 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Provider::Inspec::Config
+overrides: !ruby/object:Overrides::ResourceOverrides

--- a/mmv1/templates/inspec/examples/google_orgpolicy_folder_policy/google_orgpolicy_folder_policies.erb
+++ b/mmv1/templates/inspec/examples/google_orgpolicy_folder_policy/google_orgpolicy_folder_policies.erb
@@ -1,0 +1,5 @@
+<% gcp_project_id = "#{external_attribute(pwd, 'gcp_project_id', doc_generation)}" -%>
+  <% folder_policy = grab_attributes(pwd)['folder_policy'] -%>
+  describe google_orgpolicy_folder_policies(parent: <%= doc_generation ? "' #{folder_policy['parent']}'":"folder_policy['parent']" -%>) do
+    it { should exist }
+  end

--- a/mmv1/templates/inspec/examples/google_orgpolicy_folder_policy/google_orgpolicy_folder_policy.erb
+++ b/mmv1/templates/inspec/examples/google_orgpolicy_folder_policy/google_orgpolicy_folder_policy.erb
@@ -1,0 +1,11 @@
+<% gcp_project_id = "#{external_attribute(pwd, 'gcp_project_id', doc_generation)}" -%>
+<% folder_policy = grab_attributes(pwd)['folder_policy'] -%>
+describe google_orgpolicy_folder_policy(name: <%= doc_generation ? "' #{folder_policy['name']}'":"folder_policy['name']" -%>) do
+	it { should exist }
+	its('name') { should cmp <%= doc_generation ? "'#{folder_policy['name']}'" : "folder_policy['name']" -%> }
+
+end
+
+describe google_orgpolicy_folder_policy(name: "does_not_exit") do
+	it { should_not exist }
+end

--- a/mmv1/templates/inspec/examples/google_orgpolicy_folder_policy/google_orgpolicy_folder_policy_attributes.erb
+++ b/mmv1/templates/inspec/examples/google_orgpolicy_folder_policy/google_orgpolicy_folder_policy_attributes.erb
@@ -1,0 +1,3 @@
+gcp_project_id = input(:gcp_project_id, value: '<%= external_attribute(pwd, 'gcp_project_id') -%>', description: 'The GCP project identifier.')
+
+  folder_policy = input('folder_policy', value: <%= JSON.pretty_generate(grab_attributes(pwd)['folder_policy']) -%>, description: 'folder_policy description')

--- a/mmv1/templates/inspec/tests/integration/configuration/mm-attributes.yml
+++ b/mmv1/templates/inspec/tests/integration/configuration/mm-attributes.yml
@@ -942,3 +942,7 @@ project_location_environment:
   state : "value_state"
   create_time : "value_createtime"
   update_time : "value_updatetime"
+
+folder_policy:
+  name : "value_name"
+  parent : "value_parent"


### PR DESCRIPTION
Automatically generated by magic modules for service: orgpolicy and resource: Folders__policy.
This commit includes the following changes:
- Singular Resource ERB File
- Plural Resource ERB File 
- Terraform configuration
- api.yaml configuration for product orgpolicy and resource Folders__policy