### PR TITLE
CHEF-7191_5-MAGIC-MODULE-compute_v1-AcceleratorType - Resource Implementation

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -19801,3 +19801,193 @@ objects:
           - :IPV4_IPV6
           - :IPV4_ONLY
   
+
+
+    
+  - !ruby/object:Api::Resource
+    name: AcceleratorType
+    base_url: 'projects/{{project}}/zones/{{zone}}/acceleratorTypes'
+    self_link: 'projects/{{project}}/zones/{{zone}}/acceleratorTypes/{{acceleratorType}}'
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation':
+      api: 'https://cloud.google.com/compute_v1/docs'
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
+         path: 'name'
+         base_url: '{op_id}'
+         wait_ms: 1000
+      result: !ruby/object:Api::OpAsync::Result
+         path: 'response'
+         resource_inside_response: true
+      status: !ruby/object:Api::OpAsync::Status
+        path: 'done'
+        complete: True
+        allowed:
+          - True
+          - False
+      error: !ruby/object:Api::OpAsync::Error
+        path: 'error'
+        message: 'message'
+    description: |-
+        Represents an Accelerator Type resource. Google Cloud Platform provides graphics processing units (accelerators) that you can add to VM instances to improve or accelerate performance when working with intensive workloads. For more information, read GPUs on Compute Engine.
+    properties:
+  
+      - !ruby/object:Api::Type::String
+        name: 'kind'
+        description: |
+          [Output Only] The type of the resource. Always compute#acceleratorType for accelerator types.
+      - !ruby/object:Api::Type::String
+        name: 'id'
+        description: |
+          [Output Only] The unique identifier for the resource. This identifier is defined by the server.
+      - !ruby/object:Api::Type::String
+        name: 'creationTimestamp'
+        description: |
+          [Output Only] Creation timestamp in RFC3339 text format.
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+          [Output Only] Name of the resource.
+      - !ruby/object:Api::Type::String
+        name: 'description'
+        description: |
+          [Output Only] An optional textual description of the resource.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'deprecated'
+        description: |
+          Deprecation status for a public resource.
+        properties:
+            - !ruby/object:Api::Type::Enum
+              name: 'state'
+              description: |
+                The deprecation state of this resource. This can be ACTIVE, DEPRECATED, OBSOLETE, or DELETED. Operations which communicate the end of life date for an image, can use ACTIVE. Operations which create a new resource using a DEPRECATED resource will return successfully, but with a warning indicating the deprecated resource and recommending its replacement. Operations which use OBSOLETE or DELETED resources will be rejected and result in an error.
+              values:
+                - :ACTIVE
+                - :DELETED
+                - :DEPRECATED
+                - :OBSOLETE
+            - !ruby/object:Api::Type::String
+              name: 'replacement'
+              description: |
+                The URL of the suggested replacement for a deprecated resource. The suggested replacement resource must be the same kind of resource as the deprecated resource.
+            - !ruby/object:Api::Type::String
+              name: 'deprecated'
+              description: |
+                An optional RFC3339 timestamp on or after which the state of this resource is intended to change to DEPRECATED. This is only informational and the status will not change unless the client explicitly changes it.
+            - !ruby/object:Api::Type::String
+              name: 'obsolete'
+              description: |
+                An optional RFC3339 timestamp on or after which the state of this resource is intended to change to OBSOLETE. This is only informational and the status will not change unless the client explicitly changes it.
+            - !ruby/object:Api::Type::String
+              name: 'deleted'
+              description: |
+                An optional RFC3339 timestamp on or after which the state of this resource is intended to change to DELETED. This is only informational and the status will not change unless the client explicitly changes it.
+      - !ruby/object:Api::Type::String
+        name: 'zone'
+        description: |
+          [Output Only] The name of the zone where the accelerator type resides, such as us-central1-a. You must specify this field as part of the HTTP request URL. It is not settable as a field in the request body.
+      - !ruby/object:Api::Type::String
+        name: 'selfLink'
+        description: |
+          [Output Only] Server-defined, fully qualified URL for this resource.
+      - !ruby/object:Api::Type::Integer
+        name: 'maximumCardsPerInstance'
+        description: |
+          [Output Only] Maximum number of accelerator cards allowed per instance.
+  
+
+
+    
+  - !ruby/object:Api::Resource
+    name: AcceleratorType
+    base_url: 'projects/{{project}}/zones/{{zone}}/acceleratorTypes'
+    self_link: 'projects/{{project}}/zones/{{zone}}/acceleratorTypes/{{acceleratorType}}'
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation':
+      api: 'https://cloud.google.com/compute_v1/docs'
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
+         path: 'name'
+         base_url: '{op_id}'
+         wait_ms: 1000
+      result: !ruby/object:Api::OpAsync::Result
+         path: 'response'
+         resource_inside_response: true
+      status: !ruby/object:Api::OpAsync::Status
+        path: 'done'
+        complete: True
+        allowed:
+          - True
+          - False
+      error: !ruby/object:Api::OpAsync::Error
+        path: 'error'
+        message: 'message'
+    description: |-
+        Represents an Accelerator Type resource. Google Cloud Platform provides graphics processing units (accelerators) that you can add to VM instances to improve or accelerate performance when working with intensive workloads. For more information, read GPUs on Compute Engine.
+    properties:
+  
+      - !ruby/object:Api::Type::String
+        name: 'kind'
+        description: |
+          [Output Only] The type of the resource. Always compute#acceleratorType for accelerator types.
+      - !ruby/object:Api::Type::String
+        name: 'id'
+        description: |
+          [Output Only] The unique identifier for the resource. This identifier is defined by the server.
+      - !ruby/object:Api::Type::String
+        name: 'creationTimestamp'
+        description: |
+          [Output Only] Creation timestamp in RFC3339 text format.
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+          [Output Only] Name of the resource.
+      - !ruby/object:Api::Type::String
+        name: 'description'
+        description: |
+          [Output Only] An optional textual description of the resource.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'deprecated'
+        description: |
+          Deprecation status for a public resource.
+        properties:
+            - !ruby/object:Api::Type::Enum
+              name: 'state'
+              description: |
+                The deprecation state of this resource. This can be ACTIVE, DEPRECATED, OBSOLETE, or DELETED. Operations which communicate the end of life date for an image, can use ACTIVE. Operations which create a new resource using a DEPRECATED resource will return successfully, but with a warning indicating the deprecated resource and recommending its replacement. Operations which use OBSOLETE or DELETED resources will be rejected and result in an error.
+              values:
+                - :ACTIVE
+                - :DELETED
+                - :DEPRECATED
+                - :OBSOLETE
+            - !ruby/object:Api::Type::String
+              name: 'replacement'
+              description: |
+                The URL of the suggested replacement for a deprecated resource. The suggested replacement resource must be the same kind of resource as the deprecated resource.
+            - !ruby/object:Api::Type::String
+              name: 'deprecated'
+              description: |
+                An optional RFC3339 timestamp on or after which the state of this resource is intended to change to DEPRECATED. This is only informational and the status will not change unless the client explicitly changes it.
+            - !ruby/object:Api::Type::String
+              name: 'obsolete'
+              description: |
+                An optional RFC3339 timestamp on or after which the state of this resource is intended to change to OBSOLETE. This is only informational and the status will not change unless the client explicitly changes it.
+            - !ruby/object:Api::Type::String
+              name: 'deleted'
+              description: |
+                An optional RFC3339 timestamp on or after which the state of this resource is intended to change to DELETED. This is only informational and the status will not change unless the client explicitly changes it.
+      - !ruby/object:Api::Type::String
+        name: 'zone'
+        description: |
+          [Output Only] The name of the zone where the accelerator type resides, such as us-central1-a. You must specify this field as part of the HTTP request URL. It is not settable as a field in the request body.
+      - !ruby/object:Api::Type::String
+        name: 'selfLink'
+        description: |
+          [Output Only] Server-defined, fully qualified URL for this resource.
+      - !ruby/object:Api::Type::Integer
+        name: 'maximumCardsPerInstance'
+        description: |
+          [Output Only] Maximum number of accelerator cards allowed per instance.
+  

--- a/mmv1/templates/inspec/examples/google_compute_accelerator_type/google_compute_accelerator_type.erb
+++ b/mmv1/templates/inspec/examples/google_compute_accelerator_type/google_compute_accelerator_type.erb
@@ -1,6 +1,17 @@
 <% gcp_project_id = "#{external_attribute(pwd, 'gcp_project_id', doc_generation)}" -%>
 <% accelerator_type = grab_attributes(pwd)['accelerator_type'] -%>
-describe google_compute_accelerator_type(project: <%= gcp_project_id -%>, zone: 'us-east1-b', name: <%= doc_generation ? "'#{accelerator_type['name']}'" : "accelerator_type['name']" -%>) do
-  it { should exist }
-  it { should be_up }
+describe google_compute_v1_accelerator_type(acceleratorType: <%= doc_generation ? "' #{accelerator_type['acceleratorType']}'":"accelerator_type['acceleratorType']" -%>, project: <%= gcp_project_id -%>, zone: <%= doc_generation ? "' #{accelerator_type['zone']}'":"accelerator_type['zone']" -%>) do
+	it { should exist }
+	its('kind') { should cmp <%= doc_generation ? "'#{accelerator_type['kind']}'" : "accelerator_type['kind']" -%> }
+	its('id') { should cmp <%= doc_generation ? "'#{accelerator_type['id']}'" : "accelerator_type['id']" -%> }
+	its('creation_timestamp') { should cmp <%= doc_generation ? "'#{accelerator_type['creation_timestamp']}'" : "accelerator_type['creation_timestamp']" -%> }
+	its('name') { should cmp <%= doc_generation ? "'#{accelerator_type['name']}'" : "accelerator_type['name']" -%> }
+	its('description') { should cmp <%= doc_generation ? "'#{accelerator_type['description']}'" : "accelerator_type['description']" -%> }
+	its('zone') { should cmp <%= doc_generation ? "'#{accelerator_type['zone']}'" : "accelerator_type['zone']" -%> }
+	its('self_link') { should cmp <%= doc_generation ? "'#{accelerator_type['self_link']}'" : "accelerator_type['self_link']" -%> }
+
+end
+
+describe google_compute_v1_accelerator_type(acceleratorType: <%= doc_generation ? "' #{accelerator_type['acceleratorType']}'":"accelerator_type['acceleratorType']" -%>, project: <%= gcp_project_id -%>, zone: <%= doc_generation ? "' #{accelerator_type['zone']}'":"accelerator_type['zone']" -%>) do
+	it { should_not exist }
 end

--- a/mmv1/templates/inspec/examples/google_compute_accelerator_type/google_compute_accelerator_type_attributes.erb
+++ b/mmv1/templates/inspec/examples/google_compute_accelerator_type/google_compute_accelerator_type_attributes.erb
@@ -1,2 +1,3 @@
 gcp_project_id = input(:gcp_project_id, value: '<%= external_attribute(pwd, 'gcp_project_id') -%>', description: 'The GCP project identifier.')
-accelerator_type = input('accelerator_type', value: <%= JSON.pretty_generate(grab_attributes(pwd)['name']) -%>, description: 'The accelerator type')
+
+  accelerator_type = input('accelerator_type', value: <%= JSON.pretty_generate(grab_attributes(pwd)['accelerator_type']) -%>, description: 'accelerator_type description')

--- a/mmv1/templates/inspec/examples/google_compute_accelerator_type/google_compute_accelerator_types.erb
+++ b/mmv1/templates/inspec/examples/google_compute_accelerator_type/google_compute_accelerator_types.erb
@@ -1,5 +1,5 @@
 <% gcp_project_id = "#{external_attribute(pwd, 'gcp_project_id', doc_generation)}" -%>
-describe google_compute_accelerator_types(project: <%= gcp_project_id -%>, zone: 'us-east1-b') do
-it { should exist }
-it { should be_up }
-end
+  <% accelerator_type = grab_attributes(pwd)['accelerator_type'] -%>
+  describe google_compute_v1_accelerator_types(project: <%= gcp_project_id -%>, zone: <%= doc_generation ? "' #{accelerator_type['zone']}'":"accelerator_type['zone']" -%>) do
+    it { should exist }
+  end


### PR DESCRIPTION
Automatically generated by magic modules for service: compute_v1 and resource: AcceleratorType.
This commit includes the following changes:
- Singular Resource ERB File
- Plural Resource ERB File 
- Terraform configuration
- api.yaml configuration for product compute_v1 and resource AcceleratorType