### PR TITLE
CHEF-7193_8-MAGIC-MODULE-compute_v1-MachineType - Resource Implementation

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -19801,3 +19801,281 @@ objects:
           - :IPV4_IPV6
           - :IPV4_ONLY
   
+
+
+    
+  - !ruby/object:Api::Resource
+    name: MachineType
+    base_url: 'projects/{{project}}/zones/{{zone}}/machineTypes'
+    self_link: 'projects/{{project}}/zones/{{zone}}/machineTypes/{{machineType}}'
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation':
+      api: 'https://cloud.google.com/compute_v1/docs'
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
+         path: 'name'
+         base_url: '{op_id}'
+         wait_ms: 1000
+      result: !ruby/object:Api::OpAsync::Result
+         path: 'response'
+         resource_inside_response: true
+      status: !ruby/object:Api::OpAsync::Status
+        path: 'done'
+        complete: True
+        allowed:
+          - True
+          - False
+      error: !ruby/object:Api::OpAsync::Error
+        path: 'error'
+        message: 'message'
+    description: |-
+        Represents a Machine Type resource. You can use specific machine types for your VM instances based on performance and pricing requirements. For more information, read Machine Types.
+    properties:
+  
+      - !ruby/object:Api::Type::String
+        name: 'kind'
+        description: |
+          [Output Only] The type of the resource. Always compute#machineType for machine types.
+      - !ruby/object:Api::Type::String
+        name: 'id'
+        description: |
+          [Output Only] The unique identifier for the resource. This identifier is defined by the server.
+      - !ruby/object:Api::Type::String
+        name: 'creationTimestamp'
+        description: |
+          [Output Only] Creation timestamp in RFC3339 text format.
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+          [Output Only] Name of the resource.
+      - !ruby/object:Api::Type::String
+        name: 'description'
+        description: |
+          [Output Only] An optional textual description of the resource.
+      - !ruby/object:Api::Type::Integer
+        name: 'guestCpus'
+        description: |
+          [Output Only] The number of virtual CPUs that are available to the instance.
+      - !ruby/object:Api::Type::Integer
+        name: 'memoryMb'
+        description: |
+          [Output Only] The amount of physical memory available to the instance, defined in MB.
+      - !ruby/object:Api::Type::Integer
+        name: 'imageSpaceGb'
+        description: |
+          [Deprecated] This property is deprecated and will never be populated with any relevant values.
+      - !ruby/object:Api::Type::Array
+        name: 'scratchDisks'
+        description: |
+          [Output Only] A list of extended scratch disks assigned to the instance.
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            - !ruby/object:Api::Type::Integer
+              name: 'diskGb'
+              description: |
+                Size of the scratch disk, defined in GB.
+      - !ruby/object:Api::Type::Integer
+        name: 'maximumPersistentDisks'
+        description: |
+          [Output Only] Maximum persistent disks allowed.
+      - !ruby/object:Api::Type::String
+        name: 'maximumPersistentDisksSizeGb'
+        description: |
+          [Output Only] Maximum total persistent disks size (GB) allowed.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'deprecated'
+        description: |
+          Deprecation status for a public resource.
+        properties:
+            - !ruby/object:Api::Type::Enum
+              name: 'state'
+              description: |
+                The deprecation state of this resource. This can be ACTIVE, DEPRECATED, OBSOLETE, or DELETED. Operations which communicate the end of life date for an image, can use ACTIVE. Operations which create a new resource using a DEPRECATED resource will return successfully, but with a warning indicating the deprecated resource and recommending its replacement. Operations which use OBSOLETE or DELETED resources will be rejected and result in an error.
+              values:
+                - :ACTIVE
+                - :DELETED
+                - :DEPRECATED
+                - :OBSOLETE
+            - !ruby/object:Api::Type::String
+              name: 'replacement'
+              description: |
+                The URL of the suggested replacement for a deprecated resource. The suggested replacement resource must be the same kind of resource as the deprecated resource.
+            - !ruby/object:Api::Type::String
+              name: 'deprecated'
+              description: |
+                An optional RFC3339 timestamp on or after which the state of this resource is intended to change to DEPRECATED. This is only informational and the status will not change unless the client explicitly changes it.
+            - !ruby/object:Api::Type::String
+              name: 'obsolete'
+              description: |
+                An optional RFC3339 timestamp on or after which the state of this resource is intended to change to OBSOLETE. This is only informational and the status will not change unless the client explicitly changes it.
+            - !ruby/object:Api::Type::String
+              name: 'deleted'
+              description: |
+                An optional RFC3339 timestamp on or after which the state of this resource is intended to change to DELETED. This is only informational and the status will not change unless the client explicitly changes it.
+      - !ruby/object:Api::Type::String
+        name: 'zone'
+        description: |
+          [Output Only] The name of the zone where the machine type resides, such as us-central1-a.
+      - !ruby/object:Api::Type::String
+        name: 'selfLink'
+        description: |
+          [Output Only] Server-defined URL for the resource.
+      - !ruby/object:Api::Type::Boolean
+        name: 'isSharedCpu'
+        description: |
+          [Output Only] Whether this machine type has a shared CPU. See Shared-core machine types for more information.
+      - !ruby/object:Api::Type::Array
+        name: 'accelerators'
+        description: |
+          [Output Only] A list of accelerator configurations assigned to this machine type.
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            - !ruby/object:Api::Type::String
+              name: 'guestAcceleratorType'
+              description: |
+                The accelerator type resource name, not a full URL, e.g. nvidia-tesla-t4.
+            - !ruby/object:Api::Type::Integer
+              name: 'guestAcceleratorCount'
+              description: |
+                Number of accelerator cards exposed to the guest.
+  
+
+
+    
+  - !ruby/object:Api::Resource
+    name: MachineType
+    base_url: 'projects/{{project}}/zones/{{zone}}/machineTypes'
+    self_link: 'projects/{{project}}/zones/{{zone}}/machineTypes/{{machineType}}'
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation':
+      api: 'https://cloud.google.com/compute_v1/docs'
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
+         path: 'name'
+         base_url: '{op_id}'
+         wait_ms: 1000
+      result: !ruby/object:Api::OpAsync::Result
+         path: 'response'
+         resource_inside_response: true
+      status: !ruby/object:Api::OpAsync::Status
+        path: 'done'
+        complete: True
+        allowed:
+          - True
+          - False
+      error: !ruby/object:Api::OpAsync::Error
+        path: 'error'
+        message: 'message'
+    description: |-
+        Represents a Machine Type resource. You can use specific machine types for your VM instances based on performance and pricing requirements. For more information, read Machine Types.
+    properties:
+  
+      - !ruby/object:Api::Type::String
+        name: 'kind'
+        description: |
+          [Output Only] The type of the resource. Always compute#machineType for machine types.
+      - !ruby/object:Api::Type::String
+        name: 'id'
+        description: |
+          [Output Only] The unique identifier for the resource. This identifier is defined by the server.
+      - !ruby/object:Api::Type::String
+        name: 'creationTimestamp'
+        description: |
+          [Output Only] Creation timestamp in RFC3339 text format.
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+          [Output Only] Name of the resource.
+      - !ruby/object:Api::Type::String
+        name: 'description'
+        description: |
+          [Output Only] An optional textual description of the resource.
+      - !ruby/object:Api::Type::Integer
+        name: 'guestCpus'
+        description: |
+          [Output Only] The number of virtual CPUs that are available to the instance.
+      - !ruby/object:Api::Type::Integer
+        name: 'memoryMb'
+        description: |
+          [Output Only] The amount of physical memory available to the instance, defined in MB.
+      - !ruby/object:Api::Type::Integer
+        name: 'imageSpaceGb'
+        description: |
+          [Deprecated] This property is deprecated and will never be populated with any relevant values.
+      - !ruby/object:Api::Type::Array
+        name: 'scratchDisks'
+        description: |
+          [Output Only] A list of extended scratch disks assigned to the instance.
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            - !ruby/object:Api::Type::Integer
+              name: 'diskGb'
+              description: |
+                Size of the scratch disk, defined in GB.
+      - !ruby/object:Api::Type::Integer
+        name: 'maximumPersistentDisks'
+        description: |
+          [Output Only] Maximum persistent disks allowed.
+      - !ruby/object:Api::Type::String
+        name: 'maximumPersistentDisksSizeGb'
+        description: |
+          [Output Only] Maximum total persistent disks size (GB) allowed.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'deprecated'
+        description: |
+          Deprecation status for a public resource.
+        properties:
+            - !ruby/object:Api::Type::Enum
+              name: 'state'
+              description: |
+                The deprecation state of this resource. This can be ACTIVE, DEPRECATED, OBSOLETE, or DELETED. Operations which communicate the end of life date for an image, can use ACTIVE. Operations which create a new resource using a DEPRECATED resource will return successfully, but with a warning indicating the deprecated resource and recommending its replacement. Operations which use OBSOLETE or DELETED resources will be rejected and result in an error.
+              values:
+                - :ACTIVE
+                - :DELETED
+                - :DEPRECATED
+                - :OBSOLETE
+            - !ruby/object:Api::Type::String
+              name: 'replacement'
+              description: |
+                The URL of the suggested replacement for a deprecated resource. The suggested replacement resource must be the same kind of resource as the deprecated resource.
+            - !ruby/object:Api::Type::String
+              name: 'deprecated'
+              description: |
+                An optional RFC3339 timestamp on or after which the state of this resource is intended to change to DEPRECATED. This is only informational and the status will not change unless the client explicitly changes it.
+            - !ruby/object:Api::Type::String
+              name: 'obsolete'
+              description: |
+                An optional RFC3339 timestamp on or after which the state of this resource is intended to change to OBSOLETE. This is only informational and the status will not change unless the client explicitly changes it.
+            - !ruby/object:Api::Type::String
+              name: 'deleted'
+              description: |
+                An optional RFC3339 timestamp on or after which the state of this resource is intended to change to DELETED. This is only informational and the status will not change unless the client explicitly changes it.
+      - !ruby/object:Api::Type::String
+        name: 'zone'
+        description: |
+          [Output Only] The name of the zone where the machine type resides, such as us-central1-a.
+      - !ruby/object:Api::Type::String
+        name: 'selfLink'
+        description: |
+          [Output Only] Server-defined URL for the resource.
+      - !ruby/object:Api::Type::Boolean
+        name: 'isSharedCpu'
+        description: |
+          [Output Only] Whether this machine type has a shared CPU. See Shared-core machine types for more information.
+      - !ruby/object:Api::Type::Array
+        name: 'accelerators'
+        description: |
+          [Output Only] A list of accelerator configurations assigned to this machine type.
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            - !ruby/object:Api::Type::String
+              name: 'guestAcceleratorType'
+              description: |
+                The accelerator type resource name, not a full URL, e.g. nvidia-tesla-t4.
+            - !ruby/object:Api::Type::Integer
+              name: 'guestAcceleratorCount'
+              description: |
+                Number of accelerator cards exposed to the guest.
+  

--- a/mmv1/templates/inspec/examples/google_compute_machine_type/google_compute_machine_type.erb
+++ b/mmv1/templates/inspec/examples/google_compute_machine_type/google_compute_machine_type.erb
@@ -1,0 +1,18 @@
+<% gcp_project_id = "#{external_attribute(pwd, 'gcp_project_id', doc_generation)}" -%>
+<% machine_type = grab_attributes(pwd)['machine_type'] -%>
+describe google_compute_machine_type(machineType: <%= doc_generation ? "' #{machine_type['machineType']}'":"machine_type['machineType']" -%>, project: <%= gcp_project_id -%>, zone: <%= doc_generation ? "' #{machine_type['zone']}'":"machine_type['zone']" -%>) do
+	it { should exist }
+	its('kind') { should cmp <%= doc_generation ? "'#{machine_type['kind']}'" : "machine_type['kind']" -%> }
+	its('id') { should cmp <%= doc_generation ? "'#{machine_type['id']}'" : "machine_type['id']" -%> }
+	its('creation_timestamp') { should cmp <%= doc_generation ? "'#{machine_type['creation_timestamp']}'" : "machine_type['creation_timestamp']" -%> }
+	its('name') { should cmp <%= doc_generation ? "'#{machine_type['name']}'" : "machine_type['name']" -%> }
+	its('description') { should cmp <%= doc_generation ? "'#{machine_type['description']}'" : "machine_type['description']" -%> }
+	its('maximum_persistent_disks_size_gb') { should cmp <%= doc_generation ? "'#{machine_type['maximum_persistent_disks_size_gb']}'" : "machine_type['maximum_persistent_disks_size_gb']" -%> }
+	its('zone') { should cmp <%= doc_generation ? "'#{machine_type['zone']}'" : "machine_type['zone']" -%> }
+	its('self_link') { should cmp <%= doc_generation ? "'#{machine_type['self_link']}'" : "machine_type['self_link']" -%> }
+
+end
+
+describe google_compute_machine_type(machineType: <%= doc_generation ? "' #{machine_type['machineType']}'":"machine_type['machineType']" -%>, project: <%= gcp_project_id -%>, zone: <%= doc_generation ? "' #{machine_type['zone']}'":"machine_type['zone']" -%>) do
+	it { should_not exist }
+end

--- a/mmv1/templates/inspec/examples/google_compute_machine_type/google_compute_machine_type_attributes.erb
+++ b/mmv1/templates/inspec/examples/google_compute_machine_type/google_compute_machine_type_attributes.erb
@@ -1,0 +1,3 @@
+gcp_project_id = input(:gcp_project_id, value: '<%= external_attribute(pwd, 'gcp_project_id') -%>', description: 'The GCP project identifier.')
+
+  machine_type = input('machine_type', value: <%= JSON.pretty_generate(grab_attributes(pwd)['machine_type']) -%>, description: 'machine_type description')

--- a/mmv1/templates/inspec/examples/google_compute_machine_type/google_compute_machine_types.erb
+++ b/mmv1/templates/inspec/examples/google_compute_machine_type/google_compute_machine_types.erb
@@ -1,0 +1,5 @@
+<% gcp_project_id = "#{external_attribute(pwd, 'gcp_project_id', doc_generation)}" -%>
+  <% machine_type = grab_attributes(pwd)['machine_type'] -%>
+  describe google_compute_machine_types(project: <%= gcp_project_id -%>, zone: <%= doc_generation ? "' #{machine_type['zone']}'":"machine_type['zone']" -%>) do
+    it { should exist }
+  end


### PR DESCRIPTION
Automatically generated by magic modules for service: compute_v1 and resource: MachineType.
This commit includes the following changes:
- Singular Resource ERB File
- Plural Resource ERB File 
- Terraform configuration
- api.yaml configuration for product compute_v1 and resource MachineType