### PR TITLE
CHEF-7342_2-MAGIC-MODULE-compute_v1-GlobalNetworkEndpointGroup - Resource Implementation

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -19801,3 +19801,180 @@ objects:
           - :IPV4_IPV6
           - :IPV4_ONLY
   
+
+
+    
+  - !ruby/object:Api::Resource
+    name: GlobalNetworkEndpointGroup
+    base_url: 'projects/{{project}}/global/networkEndpointGroups'
+    self_link: 'projects/{{project}}/global/networkEndpointGroups/{{networkEndpointGroup}}'
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation':
+      api: 'https://cloud.google.com/compute_v1/docs'
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
+         path: 'name'
+         base_url: '{op_id}'
+         wait_ms: 1000
+      result: !ruby/object:Api::OpAsync::Result
+         path: 'response'
+         resource_inside_response: true
+      status: !ruby/object:Api::OpAsync::Status
+        path: 'done'
+        complete: True
+        allowed:
+          - True
+          - False
+      error: !ruby/object:Api::OpAsync::Error
+        path: 'error'
+        message: 'message'
+    description: |-
+        Represents a collection of network endpoints. A network endpoint group (NEG) defines how a set of endpoints should be reached, whether they are reachable, and where they are located. For more information about using NEGs for different use cases, see Network endpoint groups overview.
+    properties:
+  
+      - !ruby/object:Api::Type::String
+        name: 'kind'
+        description: |
+          [Output Only] Type of the resource. Always compute#networkEndpointGroup for network endpoint group.
+      - !ruby/object:Api::Type::String
+        name: 'id'
+        description: |
+          [Output Only] The unique identifier for the resource. This identifier is defined by the server.
+      - !ruby/object:Api::Type::String
+        name: 'creationTimestamp'
+        description: |
+          [Output Only] Creation timestamp in RFC3339 text format.
+      - !ruby/object:Api::Type::String
+        name: 'selfLink'
+        description: |
+          [Output Only] Server-defined URL for the resource.
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+          Name of the resource; provided by the client when the resource is created. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.
+      - !ruby/object:Api::Type::String
+        name: 'description'
+        description: |
+          An optional description of this resource. Provide this property when you create the resource.
+      - !ruby/object:Api::Type::Enum
+        name: 'networkEndpointType'
+        description: |
+          Type of network endpoints in this network endpoint group. Can be one of GCE_VM_IP, GCE_VM_IP_PORT, NON_GCP_PRIVATE_IP_PORT, INTERNET_FQDN_PORT, INTERNET_IP_PORT, SERVERLESS, PRIVATE_SERVICE_CONNECT.
+        values:
+          - :GCE_VM_IP
+          - :GCE_VM_IP_PORT
+          - :INTERNET_FQDN_PORT
+          - :INTERNET_IP_PORT
+          - :NON_GCP_PRIVATE_IP_PORT
+          - :PRIVATE_SERVICE_CONNECT
+          - :SERVERLESS
+      - !ruby/object:Api::Type::Integer
+        name: 'size'
+        description: |
+          [Output only] Number of network endpoints in the network endpoint group.
+      - !ruby/object:Api::Type::String
+        name: 'region'
+        description: |
+          [Output Only] The URL of the region where the network endpoint group is located.
+      - !ruby/object:Api::Type::String
+        name: 'zone'
+        description: |
+          [Output Only] The URL of the zone where the network endpoint group is located.
+      - !ruby/object:Api::Type::String
+        name: 'network'
+        description: |
+          The URL of the network to which all network endpoints in the NEG belong. Uses "default" project network if unspecified.
+      - !ruby/object:Api::Type::String
+        name: 'subnetwork'
+        description: |
+          Optional URL of the subnetwork to which all network endpoints in the NEG belong.
+      - !ruby/object:Api::Type::Integer
+        name: 'defaultPort'
+        description: |
+          The default port used if the port number is not specified in the network endpoint.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'annotations'
+        description: |
+          Metadata defined as annotations on the network endpoint group.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'additionalProperties'
+            description: |
+              
+      - !ruby/object:Api::Type::NestedObject
+        name: 'cloudRun'
+        description: |
+          Configuration for a Cloud Run network endpoint group (NEG). The service must be provided explicitly or in the URL mask. The tag is optional, may be provided explicitly or in the URL mask. Note: Cloud Run service must be in the same project and located in the same region as the Serverless NEG.
+        properties:
+            - !ruby/object:Api::Type::String
+              name: 'service'
+              description: |
+                Cloud Run service is the main resource of Cloud Run. The service must be 1-63 characters long, and comply with RFC1035. Example value: "run-service".
+            - !ruby/object:Api::Type::String
+              name: 'tag'
+              description: |
+                Optional Cloud Run tag represents the "named-revision" to provide additional fine-grained traffic routing information. The tag must be 1-63 characters long, and comply with RFC1035. Example value: "revision-0010".
+            - !ruby/object:Api::Type::String
+              name: 'urlMask'
+              description: |
+                A template to parse <service> and <tag> fields from a request URL. URL mask allows for routing to multiple Run services without having to create multiple network endpoint groups and backend services. For example, request URLs "foo1.domain.com/bar1" and "foo1.domain.com/bar2" can be backed by the same Serverless Network Endpoint Group (NEG) with URL mask "<tag>.domain.com/<service>". The URL mask will parse them to { service="bar1", tag="foo1" } and { service="bar2", tag="foo2" } respectively.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'appEngine'
+        description: |
+          Configuration for an App Engine network endpoint group (NEG). The service is optional, may be provided explicitly or in the URL mask. The version is optional and can only be provided explicitly or in the URL mask when service is present. Note: App Engine service must be in the same project and located in the same region as the Serverless NEG.
+        properties:
+            - !ruby/object:Api::Type::String
+              name: 'service'
+              description: |
+                Optional serving service. The service name is case-sensitive and must be 1-63 characters long. Example value: "default", "my-service".
+            - !ruby/object:Api::Type::String
+              name: 'version'
+              description: |
+                Optional serving version. The version name is case-sensitive and must be 1-100 characters long. Example value: "v1", "v2".
+            - !ruby/object:Api::Type::String
+              name: 'urlMask'
+              description: |
+                A template to parse service and version fields from a request URL. URL mask allows for routing to multiple App Engine services without having to create multiple Network Endpoint Groups and backend services. For example, the request URLs "foo1-dot-appname.appspot.com/v1" and "foo1-dot-appname.appspot.com/v2" can be backed by the same Serverless NEG with URL mask "<service>-dot-appname.appspot.com/<version>". The URL mask will parse them to { service = "foo1", version = "v1" } and { service = "foo1", version = "v2" } respectively.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'cloudFunction'
+        description: |
+          Configuration for a Cloud Function network endpoint group (NEG). The function must be provided explicitly or in the URL mask. Note: Cloud Function must be in the same project and located in the same region as the Serverless NEG.
+        properties:
+            - !ruby/object:Api::Type::String
+              name: 'function'
+              description: |
+                A user-defined name of the Cloud Function. The function name is case-sensitive and must be 1-63 characters long. Example value: "func1".
+            - !ruby/object:Api::Type::String
+              name: 'urlMask'
+              description: |
+                A template to parse function field from a request URL. URL mask allows for routing to multiple Cloud Functions without having to create multiple Network Endpoint Groups and backend services. For example, request URLs " mydomain.com/function1" and "mydomain.com/function2" can be backed by the same Serverless NEG with URL mask "/<function>". The URL mask will parse them to { function = "function1" } and { function = "function2" } respectively.
+      - !ruby/object:Api::Type::String
+        name: 'pscTargetService'
+        description: |
+          The target service url used to set up private service connection to a Google API or a PSC Producer Service Attachment. An example value is: "asia-northeast3-cloudkms.googleapis.com"
+      - !ruby/object:Api::Type::NestedObject
+        name: 'pscData'
+        description: |
+          All data that is specifically relevant to only network endpoint groups of type PRIVATE_SERVICE_CONNECT.
+        properties:
+            - !ruby/object:Api::Type::String
+              name: 'consumerPscAddress'
+              description: |
+                [Output Only] Address allocated from given subnetwork for PSC. This IP address acts as a VIP for a PSC NEG, allowing it to act as an endpoint in L7 PSC-XLB.
+            - !ruby/object:Api::Type::String
+              name: 'pscConnectionId'
+              description: |
+                [Output Only] The PSC connection id of the PSC Network Endpoint Group Consumer.
+            - !ruby/object:Api::Type::Enum
+              name: 'pscConnectionStatus'
+              description: |
+                [Output Only] The connection status of the PSC Forwarding Rule.
+              values:
+                - :ACCEPTED
+                - :CLOSED
+                - :NEEDS_ATTENTION
+                - :PENDING
+                - :REJECTED
+                - :STATUS_UNSPECIFIED
+  

--- a/mmv1/templates/inspec/examples/google_compute_global_network_endpoint_group/google_compute_global_network_endpoint_group.erb
+++ b/mmv1/templates/inspec/examples/google_compute_global_network_endpoint_group/google_compute_global_network_endpoint_group.erb
@@ -1,12 +1,22 @@
 <% gcp_project_id = "#{external_attribute(pwd, 'gcp_project_id', doc_generation)}" -%>
 <% global_network_endpoint_group = grab_attributes(pwd)['global_network_endpoint_group'] -%>
+describe google_compute_global_network_endpoint_group(networkEndpointGroup: <%= doc_generation ? "' #{global_network_endpoint_group['networkEndpointGroup']}'":"global_network_endpoint_group['networkEndpointGroup']" -%>, project: <%= gcp_project_id -%>) do
+	it { should exist }
+	its('kind') { should cmp <%= doc_generation ? "'#{global_network_endpoint_group['kind']}'" : "global_network_endpoint_group['kind']" -%> }
+	its('id') { should cmp <%= doc_generation ? "'#{global_network_endpoint_group['id']}'" : "global_network_endpoint_group['id']" -%> }
+	its('creation_timestamp') { should cmp <%= doc_generation ? "'#{global_network_endpoint_group['creation_timestamp']}'" : "global_network_endpoint_group['creation_timestamp']" -%> }
+	its('self_link') { should cmp <%= doc_generation ? "'#{global_network_endpoint_group['self_link']}'" : "global_network_endpoint_group['self_link']" -%> }
+	its('name') { should cmp <%= doc_generation ? "'#{global_network_endpoint_group['name']}'" : "global_network_endpoint_group['name']" -%> }
+	its('description') { should cmp <%= doc_generation ? "'#{global_network_endpoint_group['description']}'" : "global_network_endpoint_group['description']" -%> }
+	its('network_endpoint_type') { should cmp <%= doc_generation ? "'#{global_network_endpoint_group['network_endpoint_type']}'" : "global_network_endpoint_group['network_endpoint_type']" -%> }
+	its('region') { should cmp <%= doc_generation ? "'#{global_network_endpoint_group['region']}'" : "global_network_endpoint_group['region']" -%> }
+	its('zone') { should cmp <%= doc_generation ? "'#{global_network_endpoint_group['zone']}'" : "global_network_endpoint_group['zone']" -%> }
+	its('network') { should cmp <%= doc_generation ? "'#{global_network_endpoint_group['network']}'" : "global_network_endpoint_group['network']" -%> }
+	its('subnetwork') { should cmp <%= doc_generation ? "'#{global_network_endpoint_group['subnetwork']}'" : "global_network_endpoint_group['subnetwork']" -%> }
+	its('psc_target_service') { should cmp <%= doc_generation ? "'#{global_network_endpoint_group['psc_target_service']}'" : "global_network_endpoint_group['psc_target_service']" -%> }
 
-describe google_compute_global_network_endpoint_group(project: <%= gcp_project_id -%>, name: <%= doc_generation ? "'#{global_network_endpoint_group['name']}'" : "global_network_endpoint_group['name']" -%>) do
-  it { should exist }
-  its('default_port') { should cmp <%= doc_generation ? "'#{global_network_endpoint_group['default_port']}'" : "global_network_endpoint_group['default_port']" -%> }
-  its('network_endpoint_type'){ should cmp <%= doc_generation ? "'#{global_network_endpoint_group['network_endpoint_type']}'" : "global_network_endpoint_group['network_endpoint_type']" -%> }
 end
 
-describe google_compute_global_network_endpoint_group(project: <%= gcp_project_id -%>, name: 'nonexistent') do
-  it { should_not exist }
+describe google_compute_global_network_endpoint_group(networkEndpointGroup: <%= doc_generation ? "' #{global_network_endpoint_group['networkEndpointGroup']}'":"global_network_endpoint_group['networkEndpointGroup']" -%>, project: <%= gcp_project_id -%>) do
+	it { should_not exist }
 end

--- a/mmv1/templates/inspec/examples/google_compute_global_network_endpoint_group/google_compute_global_network_endpoint_group_attributes.erb
+++ b/mmv1/templates/inspec/examples/google_compute_global_network_endpoint_group/google_compute_global_network_endpoint_group_attributes.erb
@@ -1,2 +1,3 @@
 gcp_project_id = input(:gcp_project_id, value: '<%= external_attribute(pwd, 'gcp_project_id') -%>', description: 'The GCP project identifier.')
-global_network_endpoint_group = input('global_network_endpoint_group', value: <%= JSON.pretty_generate(grab_attributes(pwd)['global_network_endpoint_group']) -%>, description: 'Network endpoint group description')
+
+  global_network_endpoint_group = input('global_network_endpoint_group', value: <%= JSON.pretty_generate(grab_attributes(pwd)['global_network_endpoint_group']) -%>, description: 'global_network_endpoint_group description')

--- a/mmv1/templates/inspec/examples/google_compute_global_network_endpoint_group/google_compute_global_network_endpoint_groups.erb
+++ b/mmv1/templates/inspec/examples/google_compute_global_network_endpoint_group/google_compute_global_network_endpoint_groups.erb
@@ -1,8 +1,5 @@
 <% gcp_project_id = "#{external_attribute(pwd, 'gcp_project_id', doc_generation)}" -%>
-<% global_network_endpoint_group = grab_attributes(pwd)['global_network_endpoint_group'] -%>
-
-describe google_compute_global_network_endpoint_groups(project: <%= gcp_project_id -%>) do
-  its('default_ports') { should include <%= doc_generation ? "'#{global_network_endpoint_group['default_port']}'" : "global_network_endpoint_group['default_port']" -%> }
-  its('names') { should include <%= doc_generation ? "'#{global_network_endpoint_group['name']}'" : "global_network_endpoint_group['name']" -%> }
-  its('network_endpoint_types'){ should include <%= doc_generation ? "'#{global_network_endpoint_group['network_endpoint_type']}'" : "global_network_endpoint_group['network_endpoint_type']" -%> }
-end
+  <% global_network_endpoint_group = grab_attributes(pwd)['global_network_endpoint_group'] -%>
+  describe google_compute_global_network_endpoint_groups(project: <%= gcp_project_id -%>) do
+    it { should exist }
+  end


### PR DESCRIPTION
Automatically generated by magic modules for service: compute_v1 and resource: GlobalNetworkEndpointGroup.
This commit includes the following changes:
- Singular Resource ERB File
- Plural Resource ERB File 
- Terraform configuration
- api.yaml configuration for product compute_v1 and resource GlobalNetworkEndpointGroup