### PR TITLE
CHEF-12151-MAGIC-MODULE-metastore_v1-Projects__locations__services__backup - Resource Implementation

### DIFF
--- a/mmv1/products/metastore/api.yaml
+++ b/mmv1/products/metastore/api.yaml
@@ -1691,3 +1691,498 @@ objects:
           Output only. Services that are restoring from the backup.
         item_type: Api::Type::String
   
+
+
+    
+  - !ruby/object:Api::Resource
+    name: ProjectLocationServiceBackup
+    base_url: '{{+parent}}/backups'
+    self_link: '{{+name}}'
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation':
+      api: 'https://cloud.google.com/metastore/docs'
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
+         path: 'name'
+         base_url: '{op_id}'
+         wait_ms: 1000
+      result: !ruby/object:Api::OpAsync::Result
+         path: 'response'
+         resource_inside_response: true
+      status: !ruby/object:Api::OpAsync::Status
+        path: 'done'
+        complete: True
+        allowed:
+          - True
+          - False
+      error: !ruby/object:Api::OpAsync::Error
+        path: 'error'
+        message: 'message'
+    description: |-
+        The details of a backup resource.
+    properties:
+  
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+          Immutable. The relative resource name of the backup, in the following form:projects/{project_number}/locations/{location_id}/services/{service_id}/backups/{backup_id}
+      - !ruby/object:Api::Type::String
+        name: 'createTime'
+        description: |
+          Output only. The time when the backup was started.
+      - !ruby/object:Api::Type::String
+        name: 'endTime'
+        description: |
+          Output only. The time when the backup finished creating.
+      - !ruby/object:Api::Type::Enum
+        name: 'state'
+        description: |
+          Output only. The current state of the backup.
+        values:
+          - :STATE_UNSPECIFIED
+          - :CREATING
+          - :DELETING
+          - :ACTIVE
+          - :FAILED
+          - :RESTORING
+      - !ruby/object:Api::Type::NestedObject
+        name: 'serviceRevision'
+        description: |
+          A managed metastore service that serves metadata queries.
+        properties:
+            - !ruby/object:Api::Type::NestedObject
+              name: 'hiveMetastoreConfig'
+              description: |
+                Specifies configuration information specific to running Hive metastore software as the metastore service.
+              properties:
+                  - !ruby/object:Api::Type::String
+                    name: 'version'
+                    description: |
+                      Immutable. The Hive metastore schema version.
+                  - !ruby/object:Api::Type::NestedObject
+                    name: 'configOverrides'
+                    description: |
+                      A mapping of Hive metastore configuration key-value pairs to apply to the Hive metastore (configured in hive-site.xml). The mappings override system defaults (some keys cannot be overridden). These overrides are also applied to auxiliary versions and can be further customized in the auxiliary version's AuxiliaryVersionConfig.
+                    properties:
+                      - !ruby/object:Api::Type::String
+                        name: 'additionalProperties'
+                        description: |
+                          
+                  - !ruby/object:Api::Type::NestedObject
+                    name: 'kerberosConfig'
+                    description: |
+                      Configuration information for a Kerberos principal.
+                    properties:
+                        - !ruby/object:Api::Type::NestedObject
+                          name: 'keytab'
+                          description: |
+                            A securely stored value.
+                          properties:
+                              - !ruby/object:Api::Type::String
+                                name: 'cloudSecret'
+                                description: |
+                                  The relative resource name of a Secret Manager secret version, in the following form:projects/{project_number}/secrets/{secret_id}/versions/{version_id}.
+                        - !ruby/object:Api::Type::String
+                          name: 'principal'
+                          description: |
+                            A Kerberos principal that exists in the both the keytab the KDC to authenticate as. A typical principal is of the form primary/instance@REALM, but there is no exact format.
+                        - !ruby/object:Api::Type::String
+                          name: 'krb5ConfigGcsUri'
+                          description: |
+                            A Cloud Storage URI that specifies the path to a krb5.conf file. It is of the form gs://{bucket_name}/path/to/krb5.conf, although the file does not need to be named krb5.conf explicitly.
+                  - !ruby/object:Api::Type::Enum
+                    name: 'endpointProtocol'
+                    description: |
+                      The protocol to use for the metastore service endpoint. If unspecified, defaults to THRIFT.
+                    values:
+                      - :ENDPOINT_PROTOCOL_UNSPECIFIED
+                      - :THRIFT
+                      - :GRPC
+                  - !ruby/object:Api::Type::NestedObject
+                    name: 'auxiliaryVersions'
+                    description: |
+                      A mapping of Hive metastore version to the auxiliary version configuration. When specified, a secondary Hive metastore service is created along with the primary service. All auxiliary versions must be less than the service's primary version. The key is the auxiliary service name and it must match the regular expression a-z?. This means that the first character must be a lowercase letter, and all the following characters must be hyphens, lowercase letters, or digits, except the last character, which cannot be a hyphen.
+                    properties:
+                      - !ruby/object:Api::Type::String
+                        name: 'additionalProperties'
+                        description: |
+                          Configuration information for the auxiliary service versions.
+            - !ruby/object:Api::Type::String
+              name: 'name'
+              description: |
+                Immutable. The relative resource name of the metastore service, in the following format:projects/{project_number}/locations/{location_id}/services/{service_id}.
+            - !ruby/object:Api::Type::String
+              name: 'createTime'
+              description: |
+                Output only. The time when the metastore service was created.
+            - !ruby/object:Api::Type::String
+              name: 'updateTime'
+              description: |
+                Output only. The time when the metastore service was last updated.
+            - !ruby/object:Api::Type::NestedObject
+              name: 'labels'
+              description: |
+                User-defined labels for the metastore service.
+              properties:
+                - !ruby/object:Api::Type::String
+                  name: 'additionalProperties'
+                  description: |
+                    
+            - !ruby/object:Api::Type::String
+              name: 'network'
+              description: |
+                Immutable. The relative resource name of the VPC network on which the instance can be accessed. It is specified in the following form:projects/{project_number}/global/networks/{network_id}.
+            - !ruby/object:Api::Type::String
+              name: 'endpointUri'
+              description: |
+                Output only. The URI of the endpoint used to access the metastore service.
+            - !ruby/object:Api::Type::Integer
+              name: 'port'
+              description: |
+                The TCP port at which the metastore service is reached. Default: 9083.
+            - !ruby/object:Api::Type::Enum
+              name: 'state'
+              description: |
+                Output only. The current state of the metastore service.
+              values:
+                - :STATE_UNSPECIFIED
+                - :CREATING
+                - :ACTIVE
+                - :SUSPENDING
+                - :SUSPENDED
+                - :UPDATING
+                - :DELETING
+                - :ERROR
+                - :MIGRATING
+            - !ruby/object:Api::Type::String
+              name: 'stateMessage'
+              description: |
+                Output only. Additional information about the current state of the metastore service, if available.
+            - !ruby/object:Api::Type::String
+              name: 'artifactGcsUri'
+              description: |
+                Output only. A Cloud Storage URI (starting with gs://) that specifies where artifacts related to the metastore service are stored.
+            - !ruby/object:Api::Type::Enum
+              name: 'tier'
+              description: |
+                The tier of the service.
+              values:
+                - :TIER_UNSPECIFIED
+                - :DEVELOPER
+                - :ENTERPRISE
+            - !ruby/object:Api::Type::NestedObject
+              name: 'metadataIntegration'
+              description: |
+                Specifies how metastore metadata should be integrated with external services.
+              properties:
+                  - !ruby/object:Api::Type::NestedObject
+                    name: 'dataCatalogConfig'
+                    description: |
+                      Specifies how metastore metadata should be integrated with the Data Catalog service.
+                    properties:
+                        - !ruby/object:Api::Type::Boolean
+                          name: 'enabled'
+                          description: |
+                            Optional. Defines whether the metastore metadata should be synced to Data Catalog. The default value is to disable syncing metastore metadata to Data Catalog.
+                  - !ruby/object:Api::Type::NestedObject
+                    name: 'dataplexConfig'
+                    description: |
+                      Specifies how metastore metadata should be integrated with the Dataplex service.
+                    properties:
+                        - !ruby/object:Api::Type::NestedObject
+                          name: 'lakeResources'
+                          description: |
+                            A reference to the Lake resources that this metastore service is attached to. The key is the lake resource name. Example: projects/{project_number}/locations/{location_id}/lakes/{lake_id}.
+                          properties:
+                            - !ruby/object:Api::Type::String
+                              name: 'additionalProperties'
+                              description: |
+                                Represents a Lake resource
+            - !ruby/object:Api::Type::NestedObject
+              name: 'maintenanceWindow'
+              description: |
+                Maintenance window. This specifies when Dataproc Metastore may perform system maintenance operation to the service.
+              properties:
+                  - !ruby/object:Api::Type::Integer
+                    name: 'hourOfDay'
+                    description: |
+                      The hour of day (0-23) when the window starts.
+                  - !ruby/object:Api::Type::Enum
+                    name: 'dayOfWeek'
+                    description: |
+                      The day of week, when the window starts.
+                    values:
+                      - :DAY_OF_WEEK_UNSPECIFIED
+                      - :MONDAY
+                      - :TUESDAY
+                      - :WEDNESDAY
+                      - :THURSDAY
+                      - :FRIDAY
+                      - :SATURDAY
+                      - :SUNDAY
+            - !ruby/object:Api::Type::String
+              name: 'uid'
+              description: |
+                Output only. The globally unique resource identifier of the metastore service.
+            - !ruby/object:Api::Type::NestedObject
+              name: 'metadataManagementActivity'
+              description: |
+                The metadata management activities of the metastore service.
+              properties:
+                  - !ruby/object:Api::Type::Array
+                    name: 'metadataExports'
+                    description: |
+                      Output only. The latest metadata exports of the metastore service.
+                    item_type: !ruby/object:Api::Type::NestedObject
+                      properties:
+                        - !ruby/object:Api::Type::String
+                          name: 'destinationGcsUri'
+                          description: |
+                            Output only. A Cloud Storage URI of a folder that metadata are exported to, in the form of gs:////, where is automatically generated.
+                        - !ruby/object:Api::Type::String
+                          name: 'startTime'
+                          description: |
+                            Output only. The time when the export started.
+                        - !ruby/object:Api::Type::String
+                          name: 'endTime'
+                          description: |
+                            Output only. The time when the export ended.
+                        - !ruby/object:Api::Type::Enum
+                          name: 'state'
+                          description: |
+                            Output only. The current state of the export.
+                          values:
+                            - :STATE_UNSPECIFIED
+                            - :RUNNING
+                            - :SUCCEEDED
+                            - :FAILED
+                            - :CANCELLED
+                        - !ruby/object:Api::Type::Enum
+                          name: 'databaseDumpType'
+                          description: |
+                            Output only. The type of the database dump.
+                          values:
+                            - :TYPE_UNSPECIFIED
+                            - :MYSQL
+                            - :AVRO
+                  - !ruby/object:Api::Type::Array
+                    name: 'restores'
+                    description: |
+                      Output only. The latest restores of the metastore service.
+                    item_type: !ruby/object:Api::Type::NestedObject
+                      properties:
+                        - !ruby/object:Api::Type::String
+                          name: 'startTime'
+                          description: |
+                            Output only. The time when the restore started.
+                        - !ruby/object:Api::Type::String
+                          name: 'endTime'
+                          description: |
+                            Output only. The time when the restore ended.
+                        - !ruby/object:Api::Type::Enum
+                          name: 'state'
+                          description: |
+                            Output only. The current state of the restore.
+                          values:
+                            - :STATE_UNSPECIFIED
+                            - :RUNNING
+                            - :SUCCEEDED
+                            - :FAILED
+                            - :CANCELLED
+                        - !ruby/object:Api::Type::String
+                          name: 'backup'
+                          description: |
+                            Output only. The relative resource name of the metastore service backup to restore from, in the following form:projects/{project_id}/locations/{location_id}/services/{service_id}/backups/{backup_id}.
+                        - !ruby/object:Api::Type::Enum
+                          name: 'type'
+                          description: |
+                            Output only. The type of restore.
+                          values:
+                            - :RESTORE_TYPE_UNSPECIFIED
+                            - :FULL
+                            - :METADATA_ONLY
+                        - !ruby/object:Api::Type::String
+                          name: 'details'
+                          description: |
+                            Output only. The restore details containing the revision of the service to be restored to, in format of JSON.
+                        - !ruby/object:Api::Type::String
+                          name: 'backupLocation'
+                          description: |
+                            Optional. A Cloud Storage URI specifying where the backup artifacts are stored, in the format gs:///.
+            - !ruby/object:Api::Type::Enum
+              name: 'releaseChannel'
+              description: |
+                Immutable. The release channel of the service. If unspecified, defaults to STABLE.
+              values:
+                - :RELEASE_CHANNEL_UNSPECIFIED
+                - :CANARY
+                - :STABLE
+            - !ruby/object:Api::Type::NestedObject
+              name: 'encryptionConfig'
+              description: |
+                Encryption settings for the service.
+              properties:
+                  - !ruby/object:Api::Type::String
+                    name: 'kmsKey'
+                    description: |
+                      The fully qualified customer provided Cloud KMS key name to use for customer data encryption, in the following format:projects/{project_number}/locations/{location_id}/keyRings/{key_ring_id}/cryptoKeys/{crypto_key_id}.
+            - !ruby/object:Api::Type::NestedObject
+              name: 'networkConfig'
+              description: |
+                Network configuration for the Dataproc Metastore service.
+              properties:
+                  - !ruby/object:Api::Type::Array
+                    name: 'consumers'
+                    description: |
+                      Immutable. The consumer-side network configuration for the Dataproc Metastore instance.
+                    item_type: !ruby/object:Api::Type::NestedObject
+                      properties:
+                        - !ruby/object:Api::Type::String
+                          name: 'subnetwork'
+                          description: |
+                            Immutable. The subnetwork of the customer project from which an IP address is reserved and used as the Dataproc Metastore service's endpoint. It is accessible to hosts in the subnet and to all hosts in a subnet in the same region and same network. There must be at least one IP address available in the subnet's primary range. The subnet is specified in the following form:projects/{project_number}/regions/{region_id}/subnetworks/{subnetwork_id}
+                        - !ruby/object:Api::Type::String
+                          name: 'endpointUri'
+                          description: |
+                            Output only. The URI of the endpoint used to access the metastore service.
+                        - !ruby/object:Api::Type::String
+                          name: 'endpointLocation'
+                          description: |
+                            Output only. The location of the endpoint URI. Format: projects/{project}/locations/{location}.
+                  - !ruby/object:Api::Type::Boolean
+                    name: 'customRoutesEnabled'
+                    description: |
+                      Enables custom routes to be imported and exported for the Dataproc Metastore service's peered VPC network.
+            - !ruby/object:Api::Type::Enum
+              name: 'databaseType'
+              description: |
+                Immutable. The database type that the Metastore service stores its data.
+              values:
+                - :DATABASE_TYPE_UNSPECIFIED
+                - :MYSQL
+                - :SPANNER
+            - !ruby/object:Api::Type::NestedObject
+              name: 'telemetryConfig'
+              description: |
+                Telemetry Configuration for the Dataproc Metastore service.
+              properties:
+                  - !ruby/object:Api::Type::Enum
+                    name: 'logFormat'
+                    description: |
+                      The output format of the Dataproc Metastore service's logs.
+                    values:
+                      - :LOG_FORMAT_UNSPECIFIED
+                      - :LEGACY
+                      - :JSON
+            - !ruby/object:Api::Type::NestedObject
+              name: 'scalingConfig'
+              description: |
+                Represents the scaling configuration of a metastore service.
+              properties:
+                  - !ruby/object:Api::Type::Enum
+                    name: 'instanceSize'
+                    description: |
+                      An enum of readable instance sizes, with each instance size mapping to a float value (e.g. InstanceSize.EXTRA_SMALL = scaling_factor(0.1))
+                    values:
+                      - :INSTANCE_SIZE_UNSPECIFIED
+                      - :EXTRA_SMALL
+                      - :SMALL
+                      - :MEDIUM
+                      - :LARGE
+                      - :EXTRA_LARGE
+                  - !ruby/object:Api::Type::Integer
+                    name: 'scalingFactor'
+                    description: |
+                      Scaling factor, increments of 0.1 for values less than 1.0, and increments of 1.0 for values greater than 1.0.
+                  - !ruby/object:Api::Type::NestedObject
+                    name: 'autoscalingConfig'
+                    description: |
+                      Represents the autoscaling configuration of a metastore service.
+                    properties:
+                        - !ruby/object:Api::Type::Integer
+                          name: 'autoscalingFactor'
+                          description: |
+                            Output only. The scaling factor of a service with autoscaling enabled.
+                        - !ruby/object:Api::Type::Boolean
+                          name: 'autoscalingEnabled'
+                          description: |
+                            Optional. Whether or not autoscaling is enabled for this service.
+                        - !ruby/object:Api::Type::NestedObject
+                          name: 'limitConfig'
+                          description: |
+                            Represents the autoscaling limit configuration of a metastore service.
+                          properties:
+                              - !ruby/object:Api::Type::Integer
+                                name: 'maxScalingFactor'
+                                description: |
+                                  Optional. The highest scaling factor that the service should be autoscaled to.
+                              - !ruby/object:Api::Type::Integer
+                                name: 'minScalingFactor'
+                                description: |
+                                  Optional. The lowest scaling factor that the service should be autoscaled to.
+            - !ruby/object:Api::Type::NestedObject
+              name: 'scheduledBackup'
+              description: |
+                This specifies the configuration of scheduled backup.
+              properties:
+                  - !ruby/object:Api::Type::Boolean
+                    name: 'enabled'
+                    description: |
+                      Optional. Defines whether the scheduled backup is enabled. The default value is false.
+                  - !ruby/object:Api::Type::String
+                    name: 'cronSchedule'
+                    description: |
+                      Optional. The scheduled interval in Cron format, see https://en.wikipedia.org/wiki/Cron The default is empty: scheduled backup is not enabled. Must be specified to enable scheduled backups.
+                  - !ruby/object:Api::Type::String
+                    name: 'timeZone'
+                    description: |
+                      Optional. Specifies the time zone to be used when interpreting cron_schedule. Must be a time zone name from the time zone database (https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), e.g. America/Los_Angeles or Africa/Abidjan. If left unspecified, the default is UTC.
+                  - !ruby/object:Api::Type::String
+                    name: 'nextScheduledTime'
+                    description: |
+                      Output only. The time when the next backups execution is scheduled to start.
+                  - !ruby/object:Api::Type::String
+                    name: 'backupLocation'
+                    description: |
+                      Optional. A Cloud Storage URI of a folder, in the format gs:///. A sub-folder containing backup files will be stored below it.
+                  - !ruby/object:Api::Type::NestedObject
+                    name: 'latestBackup'
+                    description: |
+                      The details of the latest scheduled backup.
+                    properties:
+                        - !ruby/object:Api::Type::String
+                          name: 'backupId'
+                          description: |
+                            Output only. The ID of an in-progress scheduled backup. Empty if no backup is in progress.
+                        - !ruby/object:Api::Type::String
+                          name: 'startTime'
+                          description: |
+                            Output only. The time when the backup was started.
+                        - !ruby/object:Api::Type::Enum
+                          name: 'state'
+                          description: |
+                            Output only. The current state of the backup.
+                          values:
+                            - :STATE_UNSPECIFIED
+                            - :IN_PROGRESS
+                            - :SUCCEEDED
+                            - :FAILED
+                        - !ruby/object:Api::Type::String
+                          name: 'duration'
+                          description: |
+                            Output only. The duration of the backup completion.
+            - !ruby/object:Api::Type::Boolean
+              name: 'deletionProtection'
+              description: |
+                Optional. Indicates if the dataproc metastore should be protected against accidental deletions.
+      - !ruby/object:Api::Type::String
+        name: 'description'
+        description: |
+          The description of the backup.
+      - !ruby/object:Api::Type::Array
+        name: 'restoringServices'
+        description: |
+          Output only. Services that are restoring from the backup.
+        item_type: Api::Type::String
+  


### PR DESCRIPTION
Automatically generated by magic modules for service: metastore_v1 and resource: Projects__locations__services__backup.
This commit includes the following changes:
- Singular Resource ERB File
- Plural Resource ERB File 
- Terraform configuration
- api.yaml configuration for product metastore_v1 and resource Projects__locations__services__backup